### PR TITLE
Merge fixes for remove hole functionality in subsetting script

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - utm
   - scipy<1.8
   - numba
-  - numpy>=1.21
+  - numpy>=1.21,<1.23 # numpy.typing, scipy 1.7.x support
   - matplotlib
   - requests
   - tqdm

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -115,31 +115,6 @@ class SubsetAndCombine:
             wind_speed, num_buffer_layers, rel_island_area_min,
             out_dir, crs, out_all)
 
-
-    def _remove_holes(self, poly):
-        if isinstance(poly, MultiPolygon):
-            return unary_union([self._remove_holes(p) for p in poly.geoms])
-
-        if poly.interiors:
-            return Polygon(poly.exterior)
-
-        return poly
-
-
-    def _remove_holes_by_relative_size(self, poly, rel_size):
-        if isinstance(poly, MultiPolygon):
-            return unary_union([
-                self._remove_holes_by_relative_size(p, rel_size) for p in poly.geoms])
-
-        if poly.interiors:
-            ref_area = poly.area
-            new_interiors = [
-                    intr for intr in poly.interiors
-                    if Polygon(intr).area / ref_area > rel_size]
-            return Polygon(poly.exterior, new_interiors)
-
-        return poly
-
     def _get_largest_polygon(self, mpoly):
         if isinstance(mpoly, Polygon):
             return mpoly
@@ -199,7 +174,7 @@ class SubsetAndCombine:
                         upstream_size_max))
 
         # Islands are not of intereset when clipping high and low-res meshes
-        clip_poly = self._remove_holes(unary_union([
+        clip_poly = utils.remove_holes(unary_union([
             clip_poly_draft, *poly_upstreams]))
 
         return clip_poly
@@ -583,7 +558,7 @@ class SubsetAndCombine:
 
         _logger.info("Calculate clipped polygons...")
         start = time()
-        poly_clip_hires_0 = self._remove_holes(
+        poly_clip_hires_0 = utils.remove_holes(
                 utils.get_mesh_polygons(jig_clip_hires_0))
         poly_clip_lowres_0 = utils.get_mesh_polygons(jig_clip_lowres_0)
         _logger.info(f"Done in {time() - start} sec")
@@ -614,7 +589,7 @@ class SubsetAndCombine:
         poly_seam_5, jig_clip_lowres = self._add_overlap_to_polygon(jig_clip_lowres_0, poly_seam_4)
 
         # Cleanup buffer shape
-        poly_seam_6 = self._remove_holes_by_relative_size(
+        poly_seam_6 = utils.remove_holes_by_relative_size(
                 poly_seam_5, rel_island_area_min)
 
         poly_seam_7 = utils.drop_extra_vertex_from_polygon(poly_seam_6)
@@ -623,7 +598,7 @@ class SubsetAndCombine:
 
         _logger.info("Calculate reclipped polygons...")
         start = time()
-        poly_clip_hires = self._remove_holes(
+        poly_clip_hires = utils.remove_holes(
                 utils.get_mesh_polygons(jig_clip_hires))
         poly_clip_lowres = utils.get_mesh_polygons(jig_clip_lowres)
         _logger.info(f"Done in {time() - start} sec")

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -118,7 +118,7 @@ class SubsetAndCombine:
 
     def _remove_holes(self, poly):
         if isinstance(poly, MultiPolygon):
-            return MultiPolygon([self._remove_holes(p) for p in poly.geoms])
+            return unary_union([self._remove_holes(p) for p in poly.geoms])
 
         if poly.interiors:
             return Polygon(poly.exterior)
@@ -128,7 +128,7 @@ class SubsetAndCombine:
 
     def _remove_holes_by_relative_size(self, poly, rel_size):
         if isinstance(poly, MultiPolygon):
-            return MultiPolygon([
+            return unary_union([
                 self._remove_holes_by_relative_size(p, rel_size) for p in poly.geoms])
 
         if poly.interiors:

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -1793,7 +1793,7 @@ def remove_holes(
     elif not isinstance(poly, Polygon):
         raise ValueError(
             "The input must be either a `Polygon` or `MultiPolygon`:"
-            + f"\t{type(poly)=}"
+            + f"\tType: {type(poly)}"
         )
 
     if poly.interiors:

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -1847,7 +1847,7 @@ def remove_holes_by_relative_size(
     elif not isinstance(poly, Polygon):
         raise ValueError(
             "The input must be either a `Polygon` or `MultiPolygon`:"
-            + f"\t{type(poly)=}"
+            + f"\tType: {type(poly)}"
         )
 
     if poly.interiors:

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -19,7 +19,7 @@ from shapely.geometry import ( # type: ignore[import]
         Polygon, MultiPolygon,
         box, GeometryCollection, Point, MultiPoint,
         LineString, LinearRing)
-from shapely.ops import polygonize, linemerge
+from shapely.ops import polygonize, linemerge, unary_union
 import geopandas as gpd
 import utm
 
@@ -1755,3 +1755,106 @@ def drop_extra_vertex_from_polygon(
         poly_seam_list.append(Polygon(extr, inters))
 
     return MultiPolygon(poly_seam_list)
+
+
+def remove_holes(
+    poly: Union[Polygon, MultiPolygon]
+) -> Union[Polygon, MultiPolygon]:
+    '''Remove holes from the input polygon(s)
+
+    Given input `Polygon` or `MultiPolygon`, remove all the geometric
+    holes and return a new shape object.
+
+    Parameters
+    ----------
+    poly : Polygon or MultiPolygon
+        The input shape from which the holes are removed
+
+    Returns
+    -------
+    Polygon or MultiPolygon
+        The resulting (multi)polygon after removing the holes
+
+    See Also
+    --------
+    remove_holes_by_relative_size :
+        Remove all the whole smaller than given size from the input shape
+
+    Notes
+    -----
+    For a `Polygon` with no holes, this function returns the original
+    object. For `MultiPolygon` with no holes, the return value is a
+    `unary_union` of all the underlying `Polygon`s.
+    '''
+
+    if isinstance(poly, MultiPolygon):
+        return unary_union([remove_holes(p) for p in poly.geoms])
+
+    elif not isinstance(poly, Polygon):
+        raise ValueError(
+            "The input must be either a `Polygon` or `MultiPolygon`:"
+            + f"\t{type(poly)=}"
+        )
+
+    if poly.interiors:
+        return Polygon(poly.exterior)
+
+    return poly
+
+
+def remove_holes_by_relative_size(
+    poly: Union[Polygon, MultiPolygon],
+    rel_size:float = 0.1
+) -> Union[Polygon, MultiPolygon]:
+    '''Remove holes from the input polygon(s)
+
+    Given input `Polygon` or `MultiPolygon`, remove all the geometric
+    holes that are smaller than the input relative size `rel_size`
+    and return a new shape object.
+
+    Parameters
+    ----------
+    poly : Polygon or MultiPolygon
+        The input shape from which the holes are removed
+    rel_size : float, default=0.1
+        Maximum ratio of a hole area to the area of polygon
+
+    Returns
+    -------
+    Polygon or MultiPolygon
+        The resulting (multi)polygon after removing the holes
+
+    See Also
+    --------
+    remove_holes :
+        Remove all the whole from the input shape
+        
+    Notes
+    -----
+    For a `Polygon` with no holes, this function returns the original
+    object. For `MultiPolygon` with no holes, the return value is a
+    `unary_union` of all the underlying `Polygon`s.
+
+    If `rel_size=1` is specified the result is the same as 
+    `remove_holes` function, except for the additional cost of 
+    calculating the areas.
+    '''
+
+    if isinstance(poly, MultiPolygon):
+        return unary_union([
+            remove_holes_by_relative_size(p, rel_size) for p in poly.geoms])
+
+    elif not isinstance(poly, Polygon):
+        raise ValueError(
+            "The input must be either a `Polygon` or `MultiPolygon`:"
+            + f"\t{type(poly)=}"
+        )
+
+    if poly.interiors:
+        ref_area = poly.area
+        new_interiors = [
+                intr for intr in poly.interiors
+                if Polygon(intr).area / ref_area > rel_size]
+        return Polygon(poly.exterior, new_interiors)
+
+    return poly

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -153,7 +153,7 @@ class RemovePolygonHoles(unittest.TestCase):
         self.assertEqual(
             len(
                utils.remove_holes_by_relative_size(
-                    self._poly, 0.2
+                    self._poly, 0.15
                ).interiors
             ),
             1

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,0 +1,243 @@
+#! python
+import unittest
+from copy import deepcopy
+
+import numpy as np
+from shapely.geometry import (
+    Point,
+    LineString,
+    box,
+    Polygon,
+    MultiPolygon,
+    GeometryCollection,
+)
+
+from ocsmesh import utils
+
+
+class RemovePolygonHoles(unittest.TestCase):
+
+    def setUp(self):
+        self._main = box(0, 0, 10, 6)
+        self._aux = box(-3, -3, -1, 3)
+        self._hole1 = Point(3, 3).buffer(1.5)
+        self._hole2 = Point(7.17, 4.13).buffer(1.43)
+        self._hole1_island = Point(3.15, 3.25).buffer(1)
+        self._hole1_island_hole1 = Point(3.20, 2.99).buffer(0.25)
+
+        self._poly = Polygon(
+            self._main.boundary,
+            [
+                self._hole1.boundary,
+                self._hole2.boundary
+            ]
+        )
+        self._island = Polygon(
+            self._hole1_island.boundary,
+            [
+                self._hole1_island_hole1.boundary
+            ]
+        )
+        self._multipoly1 = MultiPolygon([self._poly, self._island])
+        self._multipoly2 = MultiPolygon([self._poly, self._island, self._aux])
+
+
+    def test_invalid_input_raises(self):
+        self.assertRaises(
+            ValueError, utils.remove_holes, Point(0, 0)
+        )
+        self.assertRaises(
+            ValueError, utils.remove_holes, LineString([[0, 0], [1, 1]])
+        )
+        self.assertRaises(
+            ValueError, utils.remove_holes, GeometryCollection()
+        )
+
+        self.assertRaises(
+            ValueError, utils.remove_holes_by_relative_size, Point(0, 0)
+        )
+        self.assertRaises(
+            ValueError, utils.remove_holes_by_relative_size, LineString([[0, 0], [1, 1]])
+        )
+        self.assertRaises(
+            ValueError, utils.remove_holes_by_relative_size, GeometryCollection()
+        )
+
+
+    def test_no_mutate_input_1(self):
+
+        utils.remove_holes(self._poly)
+        self.assertEqual(
+            len(self._poly.interiors), 2
+        )
+
+
+    def test_no_mutate_input_2(self):
+
+        utils.remove_holes_by_relative_size(self._poly, 1)
+        self.assertEqual(
+            len(self._poly.interiors), 2
+        )
+
+
+    def test_remove_polygon_holes(self):
+
+        self.assertIsInstance(
+            utils.remove_holes(self._poly), Polygon
+        )
+        self.assertTrue(
+            utils.remove_holes(self._poly).is_valid
+        )
+        self.assertEqual(
+            self._main,
+            utils.remove_holes(self._main)
+        )
+        self.assertEqual(
+            len(utils.remove_holes(self._poly).interiors),
+            0
+        )
+
+
+    def test_remove_multipolygon_holes(self):
+
+        self.assertIsInstance(
+            utils.remove_holes(self._multipoly1), Polygon
+        )
+        self.assertTrue(
+            utils.remove_holes(self._multipoly1).is_valid
+        )
+        self.assertEqual(
+            len(utils.remove_holes(self._multipoly1).interiors),
+            0
+        )
+
+        self.assertIsInstance(
+            utils.remove_holes(self._multipoly2), MultiPolygon
+        )
+        self.assertTrue(
+            utils.remove_holes(self._multipoly2).is_valid
+        )
+        self.assertEqual(
+            sum(len(p.interiors) for p in utils.remove_holes(self._multipoly2).geoms),
+            0
+        )
+
+
+    def test_remove_polygon_holes_with_size(self):
+        self.assertIsInstance(
+            utils.remove_holes_by_relative_size(self._poly, 1), Polygon
+        )
+        self.assertTrue(
+            utils.remove_holes_by_relative_size(self._poly, 1).is_valid
+        )
+        self.assertEqual(
+            self._main,
+            utils.remove_holes_by_relative_size(self._main, 1)
+        )
+        self.assertEqual(
+            len(
+               utils.remove_holes_by_relative_size(
+                    self._poly, 1
+               ).interiors
+            ),
+            0
+        )
+        self.assertEqual(
+            len(
+               utils.remove_holes_by_relative_size(
+                    self._poly, 0.5
+               ).interiors
+            ),
+            0
+        )
+        self.assertEqual(
+            len(
+               utils.remove_holes_by_relative_size(
+                    self._poly, 0.2
+               ).interiors
+            ),
+            1
+        )
+        self.assertEqual(
+            len(
+               utils.remove_holes_by_relative_size(
+                    self._poly, 0
+               ).interiors
+            ),
+            2
+        )
+
+
+
+    def test_remove_multipolygon_holes_with_size(self):
+
+        self.assertIsInstance(
+            utils.remove_holes_by_relative_size(self._multipoly1, 1),
+            Polygon
+        )
+        self.assertTrue(
+            utils.remove_holes_by_relative_size(
+                self._multipoly1, 1
+            ).is_valid
+        )
+        self.assertEqual(
+            len(
+                utils.remove_holes_by_relative_size(
+                    self._multipoly1, 1
+                ).interiors
+            ),
+            0
+        )
+        self.assertEqual(
+            sum(
+                len(p.interiors) for p in 
+                utils.remove_holes_by_relative_size(
+                    self._multipoly1,
+                    0
+                ).geoms
+            ),
+            3
+        )
+        self.assertEqual(
+            sum(
+                len(p.interiors) for p in 
+                utils.remove_holes_by_relative_size(
+                    self._multipoly1,
+                    0.1
+                ).geoms
+            ),
+            2
+        )
+        self.assertEqual(
+            sum(
+                len(p.interiors) for p in 
+                utils.remove_holes_by_relative_size(
+                    self._multipoly1,
+                    0.15
+                ).geoms
+            ),
+            1
+        )
+        self.assertEqual(
+            len(
+                utils.remove_holes_by_relative_size(
+                    self._multipoly1, 0.2
+                ).interiors
+            ),
+            0
+        )
+
+        self.assertIsInstance(
+            utils.remove_holes_by_relative_size(self._multipoly2, 1), MultiPolygon
+        )
+        self.assertTrue(
+            utils.remove_holes_by_relative_size(self._multipoly2, 1).is_valid
+        )
+        self.assertEqual(
+            sum(len(p.interiors) for p in utils.remove_holes_by_relative_size(self._multipoly2, 1).geoms),
+            0
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #28 
- Move the remove hole functionality from `subset_n_combine` script to `utils` module
- Fixes the issue of returning invalid shape
- Documentation for the newly added functionality in `utils`
- Unit tests for remove hole functionality