### PR TITLE
Fix subset and combine meshing script.

### DIFF
--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -236,7 +236,7 @@ class SubsetAndCombine:
         # Inverse of above
         clipped_mesh = utils.clip_mesh_by_shape(
                 mesh, polygon,
-                fit_inside=True,
+                fit_inside=False,
                 inverse=True,
                 check_cross_edges=True
                 )


### PR DESCRIPTION
Method for clipping mesh by buffer and adding the overlap to buffer, does not invert the operation on opposing sides of the mesh resulting in self overlap in the final combined mesh. This issue is now fixed.