### PR TITLE
Fix subtidal flow limiter bug in collector hfun

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,12 +1,13 @@
 [MASTER]
 fail-on=E
-fail-under=9.84
+fail-under=9.90
 py-version=3.9.7
 # As a temporary workaround for https://github.com/PyCQA/pylint/issues/4577
 init-hook = "import astroid; astroid.context.InferenceContext.max_inferred = 250"
 
 [MESSAGES CONTROL]
-disable=fixme,
+disable=arguments-differ,
+        fixme,
         invalid-name,
         unused-variable,
         unused-argument,
@@ -23,6 +24,7 @@ disable=fixme,
         missing-module-docstring,
         missing-class-docstring,
         missing-function-docstring,
+        super-init-not-called,
         unspecified-encoding
 
 [TYPECHECK]
@@ -34,3 +36,5 @@ generated-members=ocsmesh.driver.JigsawDriver.hfun,
                   ocsmesh.mesh.base.BaseMesh._msh_t,
                   ocsmesh.mesh.mesh.EuclideanMesh._boundaries,
                   ocsmesh.mesh.mesh.Mesh.*
+ignore-patterns=interp.py,
+                cmd.py

--- a/ocsmesh/cli/remesh_by_shape_factor.py
+++ b/ocsmesh/cli/remesh_by_shape_factor.py
@@ -26,7 +26,7 @@ logging.basicConfig(
 _logger = logging.getLogger(__name__)
 
 # Enable KML driver
-#from https://stackoverflow.com/questions/72960340/attributeerror-nonetype-object-has-no-attribute-drvsupport-when-using-fiona
+#from stackoverflow issue 72960340
 supported_drivers['KML'] = 'rw'
 supported_drivers['LIBKML'] = 'rw'
 

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -185,8 +185,7 @@ class SubsetAndCombine:
 
         if not isinstance(shape, GeometryCollection):
             raise ValueError(
-                "Expected a GeometryCollection, received {}".format(
-                    type(shape)))
+                f"Expected a GeometryCollection, received {type(shape)}")
 
         polygon_list = []
         for g in shape.geoms:

--- a/ocsmesh/features/constraint.py
+++ b/ocsmesh/features/constraint.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.spatial import cKDTree
 from scipy import constants
 
-import ocsmesh.utils as utils
+from ocsmesh import utils
 
 ConstraintValueType = Enum("ConstraintValueType", "MIN MAX")
 
@@ -269,13 +269,13 @@ class CourantNumConstraint(Constraint):
             Depth values to be used for Courant number approximations
         old_values : array of floats
             Values of mesh size function before applying the constraint
-        \*args : list
+        *args : list
             List of arguments not handled by this apply method (
             used in other constraints)
-        \*\*kwargs : dict
+        **kwargs : dict
             Dictionary of arguments not handled by this apply method (
             used in other constraints)
-            
+
         Returns
         -------
         array of floats
@@ -296,7 +296,7 @@ class CourantNumConstraint(Constraint):
         char_vel = u_mag + np.sqrt(constants.g * np.abs(ref_values))
         # For overland where h < nu the characteristic velocity is 2 * sqrt(g*h)
         char_vel[~depth_mask] = 2 * u_mag[~depth_mask]
-        
+
         temp_values = utils.get_element_size_courant(
             char_vel, self._dt, self._value
         )

--- a/ocsmesh/features/contour.py
+++ b/ocsmesh/features/contour.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from abc import ABC, abstractmethod
 
 class ContourBase(ABC):

--- a/ocsmesh/geom/collector.py
+++ b/ocsmesh/geom/collector.py
@@ -159,7 +159,7 @@ class GeomCollector(BaseGeom):
         nprocs = cpu_count() if nprocs == -1 else nprocs
 
 
-        self._elev_info = dict(zmin=zmin, zmax=zmax)
+        self._elev_info = {'zmin':zmin, 'zmax': zmax}
         self._nprocs = nprocs
         self._chunk_size = chunk_size
         self._overlap = overlap

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -1584,7 +1584,7 @@ class HfunCollector(BaseHfun):
                     hmin = self._size_info['hmin']
                 if hmax is None:
                     hmax = self._size_info['hmax']
-                hfun.add_subtidal_flow_limiter(hmin, hmax, zmax, zmin)
+                hfun.add_subtidal_flow_limiter(hmin, hmax, zmin, zmax)
 
 
     def _apply_const_val(self):
@@ -2080,7 +2080,7 @@ class HfunCollector(BaseHfun):
             else:
                 zmin = max(zmin, -99990)
 
-            big_hfun.add_subtidal_flow_limiter(hmin, hmax, zmax, zmin)
+            big_hfun.add_subtidal_flow_limiter(hmin, hmax, zmin, zmax)
 
     def _apply_const_val_fast(self, big_hfun):
         """Internal: apply specified constant value refinements.

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -648,7 +648,7 @@ class HfunCollector(BaseHfun):
         nprocs = cpu_count() if nprocs == -1 else nprocs
 
         self._applied = False
-        self._size_info = dict(hmin=hmin, hmax=hmax)
+        self._size_info = {'hmin': hmin, 'hmax': hmax}
         self._nprocs = nprocs
         self._hfun_list = []
         self._method = method

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -1362,6 +1362,14 @@ class HfunRaster(BaseHfun, Raster):
                 hfun_values = np.abs((1./3.)*(topobathy/dh))
                 # values = values.filled(np.max(values))
 
+                if hmin is not None:
+                    hfun_values[np.where(hfun_values < hmin)] = hmin
+
+                if hmax is not None:
+                    hfun_values[np.where(hfun_values > hmax)] = hmax
+
+                # Don't consider the applied values in the region
+                # outside the provided bounds
                 if upper_bound is not None:
                     idxs = np.where(topobathy > upper_bound)
                     hfun_values[idxs] = self.get_values(
@@ -1371,12 +1379,8 @@ class HfunRaster(BaseHfun, Raster):
                     hfun_values[idxs] = self.get_values(
                         band=1, window=window)[idxs]
 
-                if hmin is not None:
-                    hfun_values[np.where(hfun_values < hmin)] = hmin
 
-                if hmax is not None:
-                    hfun_values[np.where(hfun_values > hmax)] = hmax
-
+                # Apply global hmin and hmax
                 if self._hmin is not None:
                     hfun_values[np.where(hfun_values < self._hmin)] = self._hmin
                 if self._hmax is not None:

--- a/ocsmesh/ops/combine_geom.py
+++ b/ocsmesh/ops/combine_geom.py
@@ -48,20 +48,21 @@ class GeomCombine:
         nprocs = cpu_count() if nprocs == -1 else nprocs
         dem_files = [] if dem_files is None else dem_files
 
-        self._operation_info = dict(
-            dem_files=dem_files,
-            out_file=out_file,
-            out_format=out_format,
-            mesh_file=mesh_file,
-            mesh_mp_in=mesh_multipolygon,
-            ignore_mesh=ignore_mesh_final_boundary,
-            zmin=zmin,
-            zmax=zmax,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            nprocs=nprocs,
-            out_crs=out_crs,
-            base_crs=base_crs)
+        self._operation_info = {
+                'dem_files': dem_files,
+                'out_file': out_file,
+                'out_format': out_format,
+                'mesh_file': mesh_file,
+                'mesh_mp_in': mesh_multipolygon,
+                'ignore_mesh': ignore_mesh_final_boundary,
+                'zmin': zmin,
+                'zmax': zmax,
+                'chunk_size': chunk_size,
+                'overlap': overlap,
+                'nprocs': nprocs,
+                'out_crs': out_crs,
+                'base_crs': base_crs
+        }
 
     def run(self):
 

--- a/ocsmesh/ops/combine_hfun.py
+++ b/ocsmesh/ops/combine_hfun.py
@@ -35,19 +35,20 @@ class HfunCombine:
 
         self._base_exterior = None
 
-        self._operation_info = dict(
-            dem_files=dem_files,
-            out_file=out_file,
-            out_format=out_format,
-            mesh_file=mesh_file,
-            hmin=hmin,
-            hmax=hmax,
-            contours=contours,
-            constants=constants,
-            chunk_size=chunk_size,
-            overlap=overlap,
-            method=method,
-            nprocs=nprocs)
+        self._operation_info = {
+                'dem_files': dem_files,
+                'out_file': out_file,
+                'out_format': out_format,
+                'mesh_file': mesh_file,
+                'hmin': hmin,
+                'hmax': hmax,
+                'contours': contours,
+                'constants': constants,
+                'chunk_size': chunk_size,
+                'overlap': overlap,
+                'method': method,
+                'nprocs': nprocs
+        }
 
     def run(self):
 

--- a/ocsmesh/raster.py
+++ b/ocsmesh/raster.py
@@ -1824,7 +1824,7 @@ class Raster:
         """Set `resampling_method`"""
 
         if not isinstance(resampling_method, Resampling):
-            TypeError(
+            raise TypeError(
                 f'Argument resampling_method must be of type  {Resampling}, '
                 f'not type {type(resampling_method)}.')
         self._resampling_method = resampling_method


### PR DESCRIPTION
The order of arguments passed from hfun collector to each hfun raster for `add_subtidal_flow_limiter` is wrong for minimum and maximum region elevation.