### PR TITLE
Add manual boundary specification functionality

### DIFF
--- a/ocsmesh/__main__.py
+++ b/ocsmesh/__main__.py
@@ -22,19 +22,20 @@ class OCSMesh:
             nprocs = -1 if nprocs is None else nprocs
 
             if self._args.geom_cmd == "build":
-                arg_dict = dict(
-                    dem_files=self._args.dem,
-                    out_file=self._args.output,
-                    out_format=self._args.output_format,
-                    mesh_file=self._args.mesh,
-                    ignore_mesh_final_boundary=self._args.ignore_mesh_boundary,
-                    zmin=self._args.zmin,
-                    zmax=self._args.zmax,
-                    chunk_size=self._args.chunk_size,
-                    overlap=self._args.overlap,
-                    nprocs=nprocs,
-                    out_crs=self._args.output_crs,
-                    base_crs=self._args.mesh_crs)
+                arg_dict = {
+                    "dem_files": self._args.dem,
+                    "out_file": self._args.output,
+                    "out_format": self._args.output_format,
+                    "mesh_file": self._args.mesh,
+                    "ignore_mesh_final_boundary": self._args.ignore_mesh_boundary,
+                    "zmin": self._args.zmin,
+                    "zmax": self._args.zmax,
+                    "chunk_size": self._args.chunk_size,
+                    "overlap": self._args.overlap,
+                    "nprocs": nprocs,
+                    "out_crs": self._args.output_crs,
+                    "base_crs": self._args.mesh_crs
+                }
                 combine_geometry(**arg_dict)
 
         elif self._args.command == 'hfun':
@@ -45,19 +46,20 @@ class OCSMesh:
             nprocs = -1 if nprocs is None else nprocs
 
             if self._args.hfun_cmd == "build":
-                arg_dict = dict(
-                    dem_files=self._args.dem,
-                    out_file=self._args.output,
-                    out_format=self._args.output_format,
-                    mesh_file=self._args.mesh,
-                    hmin=self._args.hmin,
-                    hmax=self._args.hmax,
-                    contours=self._args.contour,
-                    constants=self._args.constants,
-                    chunk_size=self._args.chunk_size,
-                    overlap=self._args.overlap,
-                    method=self._args.method,
-                    nprocs=nprocs)
+                arg_dict = {
+                    "dem_files": self._args.dem,
+                    "out_file": self._args.output,
+                    "out_format": self._args.output_format,
+                    "mesh_file": self._args.mesh,
+                    "hmin": self._args.hmin,
+                    "hmax": self._args.hmax,
+                    "contours": self._args.contour,
+                    "constants": self._args.constants,
+                    "chunk_size": self._args.chunk_size,
+                    "overlap": self._args.overlap,
+                    "method": self._args.method,
+                    "nprocs": nprocs
+                }
                 combine_hfun(**arg_dict)
 
         elif self._args.command == 'scripts':

--- a/ocsmesh/driver.py
+++ b/ocsmesh/driver.py
@@ -110,7 +110,7 @@ class JigsawDriver:
         if output_mesh.tria3['index'].shape[0] == 0:
             _err = 'ERROR: Jigsaw returned empty mesh.'
             _logger.error(_err)
-            raise Exception(_err)
+            raise RuntimeError(_err)
 
         if self._crs is not None:
             utils.reproject(output_mesh, self._crs)

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1977,13 +1977,14 @@ class Boundaries:
                      for e, coo in enumerate(seg.coords[:-1])]
                     for seg in bnd_segs]
 
+        assigned_ids = assignment.keys()
+        bnd_id = max(assigned_ids) + 1 if len(assigned_ids) > 0 else 0
         for bnd in new_bnds:
-            assigned_ids = assignment.keys()
-            bnd_id = max(assigned_ids) + 1 if len(assigned_ids) > 0 else 0
             e0, e1 = [list(t) for t in zip(*bnd)]
             e0 = [get_id(vert) for vert in e0]
             data = e0 + [get_id(e1[-1])]
             assignment[bnd_id] = {'indexes': data, 'properties': {}}
+            bnd_id += 1
 
         return assignment
 

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -2022,6 +2022,8 @@ class Boundaries:
                         'indexes': sub, 'properties': prop
                     }
                     next_bnd_id = next_bnd_id + 1
+            else:
+                boundaries[tp_id].pop(bd_id)
 
 
         return boundaries

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1952,13 +1952,13 @@ class Boundaries:
 
     def _assign_boundary_condition_to_edges(self, edge_list, no_segment=False, init=None):
 
-
         assignment = defaultdict()
+        if isinstance(init, defaultdict):
+            assignment = deepcopy(init)
+
         if len(edge_list) == 0:
             return assignment
 
-        if isinstance(init, defaultdict):
-            assignment = deepcopy(init)
         get_id = self.mesh.nodes.get_id_by_index
 
         new_bnds = [edge_list]

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1692,9 +1692,16 @@ class Boundaries:
                             'geometry': LineString(self.mesh.coord[indexes])
                             })
 
+        crs = self.mesh.crs
         self._open = gpd.GeoDataFrame(open_boundaries)
+        if not self._open.empty and crs is not None:
+            self._open.set_crs(crs)
         self._land = gpd.GeoDataFrame(land_boundaries)
+        if not self._land.empty and crs is not None:
+            self._land.set_crs(crs)
         self._interior = gpd.GeoDataFrame(interior_boundaries)
+        if not self._interior.empty and crs is not None:
+            self._interior.set_crs(crs)
 
 
     def _refresh_boundaries(self, data):
@@ -1817,7 +1824,10 @@ class Boundaries:
                 "indexes": bnd.indexes,
                 'geometry': bnd.geometry})
 
-        return gpd.GeoDataFrame(data, crs=self.mesh.crs)
+        total_boundaries = gpd.GeoDataFrame(data)
+        if not total_boundaries.empty and self.mesh.crs is not None:
+            total_boundaries = total_boundaries.set_crs(self.mesh.crs)
+        return total_boundaries
 
     def __len__(self) -> int:
         """Returns the number of boundary segments"""

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -2027,7 +2027,7 @@ class Boundaries:
 
         # Apply splits to the boundary dictionary
         for (tp_id, bd_id), idxs in splits_idx.items():
-            prop = boundaries[tp_id][bd_id]['properties']
+            prop = boundaries[tp_id][bd_id].get('properties', {})
             lst = boundaries[tp_id][bd_id]['indexes']
             subs = []
             prev = 0

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -33,7 +33,7 @@ from pyproj import CRS, Transformer
 from scipy.interpolate import (
         RectBivariateSpline, RegularGridInterpolator)
 from shapely.geometry import (
-        LineString, box, Polygon, MultiPolygon)
+        LineString, box, Polygon, MultiPolygon, LinearRing)
 from shapely.ops import polygonize, linemerge
 
 
@@ -1607,7 +1607,7 @@ class Boundaries:
 
         int_bdry_nodes = []
         for ring in self.mesh.hull.rings.interior().itertuples():
-            if not ring.geometry.is_ccw:
+            if not LinearRing(ring.geometry).is_ccw:
                 ring.geometry = ring.geometry.reverse()
             int_ring_coo = ring.geometry.coords
             int_ring = [
@@ -2039,7 +2039,7 @@ class Boundaries:
         for edge in edge_list_ids:
             this_edge_info = edge_bdry_info.get(str(edge), None)
             if this_edge_info is None:
-                warnings.warn(f"Edge {edge} didn't have prior boundary set!")
+                warnings.warn(f"Edge boundary {edge} didn't have prior boundary set!")
                 continue
             else:
                 tp_id, bd_id, ed_idx = this_edge_info

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1969,7 +1969,7 @@ class Boundaries:
                 tuple(coo): idx
                 for idx, coo in enumerate(coords)}
 
-            #pylint: disable=not-an-iterable
+            #pylint: disable=not-an-iterable, E1101
             bnd_segs = linemerge(coords[np.array(edge_list)].tolist())
             bnd_segs = [bnd_segs] if isinstance(bnd_segs, LineString) else bnd_segs.geoms
             new_bnds = [

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1907,16 +1907,28 @@ class Boundaries:
             )
 
         # generate interior boundaries
-        for int_ring in self.nodeidxlist['interior']:
-            boundaries[interior_ibtype] = self._assign_boundary_condition_to_edges(
-                int_ring,
-                no_segment=True,
-                init=boundaries[interior_ibtype],
-            )
+        boundaries[interior_ibtype] = self._find_islands()
+
+        # refresh all boundaries
+        self._refresh_boundaries(boundaries)
+
+
+    def find_islands(self, interior_ibtype: int = 1):
+        boundaries = deepcopy(self._data)
+        boundaries[interior_ibtype] = self._find_islands()
 
         self._refresh_boundaries(boundaries)
 
 
+    def _find_islands(self):
+        islands = defaultdict()
+        for int_ring in self.nodeidxlist['interior']:
+            islands = self._assign_boundary_condition_to_edges(
+                int_ring,
+                no_segment=True,
+                init=islands,
+            )
+        return islands
 
     def set_open(self, region: Union[Polygon, MultiPolygon], merge=False):
         self._set_region(region, None, merge)

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1990,6 +1990,11 @@ class Boundaries:
             if prev < len(lst) - 1:
                 subs.append(lst[prev:])
 
+            if len(subs) == 2 and subs[0][0] == subs[1][-1]:
+                # Reconnect loops that are broken in the middle
+                subs = [[*subs[1][:-1], *subs[0]]]
+
+
             if len(subs) > 0:
                 boundaries[tp_id][bd_id] = {'indexes': subs[0], 'properties': prop}
                 next_bnd_id = max(boundaries[tp_id].keys()) + 1

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1939,7 +1939,7 @@ class Boundaries:
 
         if len(edge_list_idx) == 0:
             return
-        boundaries = self._resovle_assignment_conflict(edge_list_idx, boundaries)
+        boundaries = self._resolve_assignment_conflict(edge_list_idx, boundaries)
 
         boundaries[type_id] = self._assign_boundary_condition_to_edges(
             edge_list_idx,
@@ -1950,7 +1950,7 @@ class Boundaries:
 
 
 
-    def _resovle_assignment_conflict(self, edge_list_idx, boundaries):
+    def _resolve_assignment_conflict(self, edge_list_idx, boundaries):
 
         get_id = self.mesh.nodes.get_id_by_index
         edge_list_ids = [

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1690,7 +1690,7 @@ class Boundaries:
 
         message = (
             'This is the old API and will be deprecated in the future release!'
-            + 'use `open()` instead'
+            + ' Use `open()` instead'
         )
         warnings.warn(message, DeprecationWarning, stacklevel=2)
 

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1826,7 +1826,7 @@ class Boundaries:
         boundaries = defaultdict(defaultdict)
 
         # generate exterior boundaries
-        for poly in polys:
+        for poly in polys.geoms:
             ext_ring_coo = poly.exterior.coords
             ext_ring = np.array([
                     (coo_to_idx[ext_ring_coo[e]],
@@ -1852,10 +1852,15 @@ class Boundaries:
                 elif np.any(np.asarray((e0, e1)) == -1):
                     ocean_boundary.append(tuple(ext_ring[i, :]))
 
-            boundaries[None] = self._assign_boundary_condition_to_edges(ocean_boundary)
-            boundaries[land_ibtype] = self._assign_boundary_condition_to_edges(land_boundary)
+            boundaries[None] = self._assign_boundary_condition_to_edges(
+                ocean_boundary, init=boundaries[None]
+            )
+            boundaries[land_ibtype] = self._assign_boundary_condition_to_edges(
+                land_boundary, init=boundaries[land_ibtype]
+            )
+
         # generate interior boundaries
-        for poly in polys:
+        for poly in polys.geoms:
             interiors = poly.interiors
 
             for interior in interiors:
@@ -1966,7 +1971,7 @@ class Boundaries:
 
             #pylint: disable=not-an-iterable
             bnd_segs = linemerge(coords[np.array(edge_list)].tolist())
-            bnd_segs = [bnd_segs] if isinstance(bnd_segs, LineString) else bnd_segs
+            bnd_segs = [bnd_segs] if isinstance(bnd_segs, LineString) else bnd_segs.geoms
             new_bnds = [
                     [(coo_to_idx[seg.coords[e]], coo_to_idx[seg.coords[e + 1]])
                      for e, coo in enumerate(seg.coords[:-1])]

--- a/ocsmesh/mesh/parsers/grd.py
+++ b/ocsmesh/mesh/parsers/grd.py
@@ -54,7 +54,7 @@ def buffer_to_dict(buf: TextIO):
         boundaries[None][_bnd_id]['indexes'] = []
         while _cnt < NETA:
             boundaries[None][_bnd_id]['indexes'].append(
-                buf.readline().split()[0].strip())
+                int(buf.readline().split()[0].strip()))
             _cnt += 1
         _bnd_id += 1
     NBOU = int(buf.readline().split()[0])
@@ -72,13 +72,13 @@ def buffer_to_dict(buf: TextIO):
         while _pnt_cnt < npts:
             line = buf.readline().split()
             if len(line) == 1:
-                boundaries[ibtype][_bnd_id]['indexes'].append(line[0])
+                boundaries[ibtype][_bnd_id]['indexes'].append(int(line[0]))
             else:
                 index_construct = []
                 for val in line:
                     if '.' in val:
                         continue
-                    index_construct.append(val)
+                    index_construct.append(int(val))
                 boundaries[ibtype][_bnd_id]['indexes'].append(index_construct)
             _pnt_cnt += 1
         _nbnd_cnt += 1

--- a/ocsmesh/mesh/parsers/grd.py
+++ b/ocsmesh/mesh/parsers/grd.py
@@ -120,21 +120,21 @@ def to_string(description, nodes, elements, boundaries=None, crs=None):
     # ocean boundaries
     if boundaries is not None:
         out.append(f"{len(boundaries[None]):d} "
-                   "! total number of ocean boundaries")
+                   "! total number of open boundaries")
         # count total number of ocean boundaries
         _sum = 0
         for bnd in boundaries[None].values():
             _sum += len(bnd['indexes'])
-        out.append(f"{int(_sum):d} ! total number of ocean boundary nodes")
+        out.append(f"{int(_sum):d} ! total number of open boundary nodes")
         # write ocean boundary indexes
         for i, boundary in boundaries[None].items():
             out.append(f"{len(boundary['indexes']):d}"
-                       f" ! number of nodes for ocean_boundary_{i}")
+                       f" ! number of nodes for open_boundary_{i}")
             for idx in boundary['indexes']:
                 out.append(f"{idx}")
     else:
-        out.append("0 ! total number of ocean boundaries")
-        out.append("0 ! total number of ocean boundary nodes")
+        out.append("0 ! total number of open boundaries")
+        out.append("0 ! total number of open boundary nodes")
     # remaining boundaries
     boundaries = {} if boundaries is None else boundaries
     _cnt = 0
@@ -142,14 +142,14 @@ def to_string(description, nodes, elements, boundaries=None, crs=None):
         if key is not None:
             for bnd in boundaries[key]:
                 _cnt += 1
-    out.append(f"{_cnt:d}  ! total number of non-ocean boundaries")
+    out.append(f"{_cnt:d}  ! total number of land boundaries")
     # count remaining boundary nodes
     _cnt = 0
     for ibtype in boundaries:
         if ibtype is not None:
             for bnd in boundaries[ibtype].values():
                 _cnt += np.asarray(bnd['indexes']).size
-    out.append(f"{_cnt:d} ! Total number of non-ocean boundary nodes")
+    out.append(f"{_cnt:d} ! Total number of land boundary nodes")
     # all additional boundaries
     for ibtype, bndrys in boundaries.items():
         if ibtype is None:

--- a/ocsmesh/mesh/parsers/sms2dm.py
+++ b/ocsmesh/mesh/parsers/sms2dm.py
@@ -81,8 +81,8 @@ def geom_string(geom_type, sms2dm):
             f'{geom_type}',
             f'{elm_id}',
         ]
-        for j, _ in enumerate(geom):
-            line.append(f"{geom[j]}")
+        for g in geom:
+            line.append(f"{g}")
         f.append(' '.join(line))
     if len(f) > 0:
         return '\n'.join(f)

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -1428,7 +1428,7 @@ def limgrad(mesh, dfdx, imax=100):
                         aset[active_idx] = _iter
     if not _iter < imax:
         msg = f'limgrad() did not converge within {imax} iterations.'
-        raise Exception(msg)
+        raise RuntimeError(msg)
     return ffun
 
 

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -185,7 +185,7 @@ def get_mesh_polygons(mesh):
             res_gdf = polys_gdf[polys_gdf.intersects(pnt)]
             if len(res_gdf) == 0:
                 # How is this possible?!
-                pnts = MultiPoint([*pnts.geoms[:idx], *pnts.geoms[idx + 1:]])
+                pnts = MultiPoint([*(pnts.geoms[:idx]), *(pnts.geoms[idx + 1:])])
                 if pnts.is_empty:
                     break
 
@@ -832,6 +832,17 @@ def select_adjacent(mesh, in_indices, num_layers):
     msg = (f"Not implemented for"
            f" mshID={mesh.mshID} and dim={mesh.ndims}")
     raise NotImplementedError(msg)
+
+
+@must_be_euclidean_mesh
+def get_incident_edges(
+        mesh: jigsaw_msh_t,
+        vert_idx_list: Sequence[int],
+        ) -> Sequence[Tuple[int, int]]:
+
+    edges = get_mesh_edges(mesh, unique=True)
+    test = np.isin(edges, vert_idx_list).any(axis=1)
+    return edges[test]
 
 
 @must_be_euclidean_mesh

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -957,7 +957,7 @@ def remove_mesh_by_edge(
 
     for etype in ELEM_2D_TYPES:
         elems = getattr(mesh, etype)['index']
-        # If a given element contains to vertices from
+        # If a given element contains two vertices from
         # a crossing edge, it is selected
         test = np.sum(np.isin(elems, edge_verts), axis=1)
         elems = elems[test < 2]

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -785,8 +785,11 @@ def get_verts_in_shape(
         mesh.vert2['coord'][:,0], mesh.vert2['coord'][:,1]))
     shp_series = gpd.GeoSeries(shape)
 
+    # We need point indices in the shapes, not the shape indices
+    # query bulk returns all combination of intersections in case
+    # input shape results in multi-row series
     in_shp_idx = pt_series.sindex.query_bulk(
-            shp_series, predicate="intersects")
+            shp_series, predicate="intersects")[1]
 
     in_shp_idx = select_adjacent(mesh, in_shp_idx, num_layers=num_adjacent)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "colored-traceback", "fiona", "geoalchemy2", "geopandas",
     "jigsawpy", "matplotlib", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
-    "pyarrow", "pyproj>=3.0", "rasterio", "requests", "scipy",
+    "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "requests", "scipy",
     "shapely>=1.8, <2", "tqdm", "typing_extensions", "utm",
     ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "colored-traceback", "fiona", "geoalchemy2", "geopandas",
     "jigsawpy", "matplotlib", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
-    "pyarrow", "pygeos", "pyproj>=3.0", "rasterio", "requests", "scipy",
+    "pyarrow", "pyproj>=3.0", "rasterio", "requests", "scipy",
     "shapely>=1.8, <2", "tqdm", "typing_extensions", "utm",
     ]
 dynamic = ["version"]

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -49,6 +49,7 @@ class BoundaryExtraction(unittest.TestCase):
                 cells.append([j * nx + (i + 1), (j + 1) * nx + (i + 1), (j + 1) * nx + i])
         vals = np.ones((len(verts), 1)) * 10
 
+        # TODO: Replace with "make_mesh" util function
         mesh_msht = jigsaw_msh_t()
         mesh_msht.ndims = +2
         mesh_msht.mshID = 'euclidean-mesh'
@@ -78,20 +79,20 @@ class BoundaryExtraction(unittest.TestCase):
 
         self.mesh.boundaries.auto_generate()
 
-        bdry = self.mesh.boundaries.data
+        bdry = self.mesh.boundaries
 
         # Mesh has one segment of each boundary type
-        self.assertEqual(len(bdry[None]), 1)
-        self.assertEqual(len(bdry[0]), 1)
-        self.assertEqual(len(bdry[1]), 1)
+        self.assertEqual(len(bdry.open()), 1)
+        self.assertEqual(len(bdry.land()), 1)
+        self.assertEqual(len(bdry.interior()), 1)
 
         # Boundaries node ID list
-        self.assertEqual(bdry[None][0]['indexes'], [30, 25, 20, 15, 10, 5])
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [30, 25, 20, 15, 10, 5])
         self.assertEqual(
-            bdry[0][0]['indexes'],
+            bdry.land().iloc[0]['index_id'],
             [5, 4, 3, 2, 1, 6, 11, 16, 21, 26, 27, 28, 29, 30]
         )
-        self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
+        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_auto_boundary_2open_correctness(self):
@@ -101,19 +102,19 @@ class BoundaryExtraction(unittest.TestCase):
 
         self.mesh.boundaries.auto_generate()
 
-        bdry = self.mesh.boundaries.data
+        bdry = self.mesh.boundaries
 
         # Mesh has one segment of each boundary type
-        self.assertEqual(len(bdry[None]), 2)
-        self.assertEqual(len(bdry[0]), 2)
-        self.assertEqual(len(bdry[1]), 1)
+        self.assertEqual(len(bdry.open()), 2)
+        self.assertEqual(len(bdry.land()), 2)
+        self.assertEqual(len(bdry.interior()), 1)
 
         # Boundaries node ID list
-        self.assertEqual(bdry[None][0]['indexes'], [1, 6, 11, 16, 21, 26])
-        self.assertEqual(bdry[None][1]['indexes'], [30, 25, 20, 15, 10, 5])
-        self.assertEqual(bdry[0][0]['indexes'], [5, 4, 3, 2, 1])
-        self.assertEqual(bdry[0][1]['indexes'], [26, 27, 28, 29, 30])
-        self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 6, 11, 16, 21, 26])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [30, 25, 20, 15, 10, 5])
+        self.assertEqual(bdry.land().iloc[0]['index_id'], [5, 4, 3, 2, 1])
+        self.assertEqual(bdry.land().iloc[1]['index_id'], [26, 27, 28, 29, 30])
+        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_manual_boundary_specification_correctness(self):
@@ -125,22 +126,23 @@ class BoundaryExtraction(unittest.TestCase):
         self.mesh.boundaries.set_open(region=shape1)
         self.mesh.boundaries.set_land(region=shape2)
 
-        bdry = self.mesh.boundaries.data
+        bdry = self.mesh.boundaries
 
         # Mesh has one segment of each boundary type
-        self.assertEqual(len(bdry[None]), 2)
-        self.assertEqual(len(bdry[0]), 2)
-        self.assertEqual(len(bdry[1]), 1)
+        self.assertEqual(len(bdry.open()), 2)
+        self.assertEqual(len(bdry.land()), 2)
+        self.assertEqual(len(bdry.interior()), 1)
 
         # Boundaries node ID list
-        self.assertEqual(bdry[None][0]['indexes'], [1, 2])
-        self.assertEqual(bdry[None][1]['indexes'], [4, 5])
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [4, 5])
         self.assertEqual(
-            bdry[0][0]['indexes'],
+            bdry.land().iloc[0]['index_id'],
             [1, 6, 11, 16, 21, 26, 27, 28, 29, 30, 25, 20, 15, 10, 5]
         )
-        self.assertEqual(bdry[0][1]['indexes'], [2, 3, 4])
-        self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
+        self.assertEqual(bdry.land().iloc[1]['index_id'], [2, 3, 4])
+        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+
 
 
     def test_specified_boundary_order(self):
@@ -152,15 +154,15 @@ class BoundaryExtraction(unittest.TestCase):
         self.mesh.boundaries.set_open(region=edge_at(0, 5))
         self.mesh.boundaries.set_open(region=edge_at(4, 5))
 
-        bdry = self.mesh.boundaries.data
+        bdry = self.mesh.boundaries
 
         # Mesh has one segment of each boundary type
-        self.assertEqual(len(bdry[None]), 4)
-        self.assertEqual(len(bdry[0]), 4)
-        self.assertEqual(len(bdry[1]), 1)
+        self.assertEqual(len(bdry.open()), 4)
+        self.assertEqual(len(bdry.land()), 4)
+        self.assertEqual(len(bdry.interior()), 1)
 
-        self.assertEqual(bdry[None][0]['indexes'], [1, 2, 3])
-        self.assertEqual(bdry[None][1]['indexes'], [5, 10, 15])
-        self.assertEqual(bdry[None][2]['indexes'], [21, 26, 27])
-        self.assertEqual(bdry[None][3]['indexes'], [29, 30, 25])
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2, 3])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [5, 10, 15])
+        self.assertEqual(bdry.open().iloc[2]['index_id'], [21, 26, 27])
+        self.assertEqual(bdry.open().iloc[3]['index_id'], [29, 30, 25])
 

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -1,4 +1,5 @@
 #! python
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -270,7 +271,6 @@ class BoundaryExtraction(unittest.TestCase):
         bdry.set_open(region=edge_at(0, 0), merge=True)
         bdry.set_open(region=edge_at(0, 4), merge=True)
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 4)
         self.assertEqual(len(bdry.land()), 4)
         self.assertEqual(len(bdry.interior()), 1)
@@ -279,3 +279,21 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry.open().iloc[1]['index_id'], [5, 10, 15])
         self.assertEqual(bdry.open().iloc[2]['index_id'], [16, 21, 26, 27])
         self.assertEqual(bdry.open().iloc[3]['index_id'], [20, 25, 30, 29])
+
+
+    def test_specify_boundary_on_imported_mesh_with_boundary(self):
+        self.mesh.boundaries.auto_generate()
+
+        with tempfile.NamedTemporaryFile(suffix='.grd') as fo:
+            self.mesh.write(fo.name, format='grd', overwrite=True)
+            imported_mesh = Mesh.open(fo.name)
+
+        bdry = imported_mesh.boundaries
+
+        bdry.set_open(region=edge_at(1, 0))
+
+        self.assertEqual(len(bdry.open()), 1)
+        self.assertEqual(len(bdry.land()), 1)
+        self.assertEqual(len(bdry.interior()), 1)
+
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2, 3])

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -297,3 +297,14 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(len(bdry.interior()), 1)
 
         self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2, 3])
+
+
+    def test_auto_find_islands_only(self):
+        bdry = self.mesh.boundaries
+
+        self.assertEqual(len(bdry.interior()), 0)
+
+        bdry.find_islands()
+
+        self.assertEqual(len(bdry.interior()), 1)
+        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -130,8 +130,8 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=shape1)
-        self.mesh.boundaries.set_land(region=shape2)
+        bdry.set_open(region=shape1)
+        bdry.set_land(region=shape2)
 
         self.assertEqual(len(bdry.open()), 2)
         self.assertEqual(len(bdry.land()), 2)
@@ -153,7 +153,7 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=geometry.box(0.5, 1.5, 2.5, 3.5))
+        bdry.set_open(region=geometry.box(0.5, 1.5, 2.5, 3.5))
 
         self.assertEqual(len(bdry.open()), 0)
         self.assertEqual(len(bdry.land()), 1)
@@ -165,7 +165,7 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=geometry.Polygon([
+        bdry.set_open(region=geometry.Polygon([
             (-1, 4.5),
             (0.5, 4.5),
             (0.5, 3.5),
@@ -194,10 +194,10 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=edge_at(1, 0))
-        self.mesh.boundaries.set_open(region=edge_at(4, 1))
-        self.mesh.boundaries.set_open(region=edge_at(0, 5))
-        self.mesh.boundaries.set_open(region=edge_at(4, 5))
+        bdry.set_open(region=edge_at(1, 0))
+        bdry.set_open(region=edge_at(4, 1))
+        bdry.set_open(region=edge_at(0, 5))
+        bdry.set_open(region=edge_at(4, 5))
 
         self.assertEqual(len(bdry.open()), 4)
         self.assertEqual(len(bdry.land()), 4)
@@ -214,7 +214,7 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=edge_at(4, 5))
+        bdry.set_open(region=edge_at(4, 5))
 
         # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 1)
@@ -227,9 +227,9 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_land(region=edge_at(1, 0), merge=True)
-        self.mesh.boundaries.set_open(region=edge_at(4, 3), merge=True)
-        self.mesh.boundaries.set_open(region=edge_at(4, 4), merge=True)
+        bdry.set_land(region=edge_at(1, 0), merge=True)
+        bdry.set_open(region=edge_at(4, 3), merge=True)
+        bdry.set_open(region=edge_at(4, 4), merge=True)
 
 
         # Mesh has one segment of each boundary type
@@ -243,8 +243,8 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=edge_at(0, 0), merge=True)
-        self.mesh.boundaries.set_open(region=edge_at(4, 0), merge=True)
+        bdry.set_open(region=edge_at(0, 0), merge=True)
+        bdry.set_open(region=edge_at(4, 0), merge=True)
 
         self.assertEqual(len(bdry.open()), 2)
         self.assertEqual(len(bdry.land()), 2)
@@ -262,15 +262,13 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        self.mesh.boundaries.set_open(region=edge_at(1, 0))
-        self.mesh.boundaries.set_open(region=edge_at(4, 1))
-        self.mesh.boundaries.set_open(region=edge_at(0, 5))
-        self.mesh.boundaries.set_open(region=edge_at(4, 5))
-        self.mesh.boundaries.set_open(region=edge_at(4, 4))
-        self.mesh.boundaries.set_open(region=edge_at(0, 0), merge=True)
-        self.mesh.boundaries.set_open(region=edge_at(0, 4), merge=True)
-
-        bdry = self.mesh.boundaries
+        bdry.set_open(region=edge_at(1, 0))
+        bdry.set_open(region=edge_at(4, 1))
+        bdry.set_open(region=edge_at(0, 5))
+        bdry.set_open(region=edge_at(4, 5))
+        bdry.set_open(region=edge_at(4, 4))
+        bdry.set_open(region=edge_at(0, 0), merge=True)
+        bdry.set_open(region=edge_at(0, 4), merge=True)
 
         # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 4)
@@ -281,4 +279,3 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry.open().iloc[1]['index_id'], [5, 10, 15])
         self.assertEqual(bdry.open().iloc[2]['index_id'], [16, 21, 26, 27])
         self.assertEqual(bdry.open().iloc[3]['index_id'], [20, 25, 30, 29])
-

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -141,3 +141,26 @@ class BoundaryExtraction(unittest.TestCase):
         )
         self.assertEqual(bdry[0][1]['indexes'], [2, 3, 4])
         self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
+
+
+    def test_specified_boundary_order(self):
+        edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)
+
+        self.mesh.boundaries.auto_generate()
+        self.mesh.boundaries.set_open(region=edge_at(1, 0))
+        self.mesh.boundaries.set_open(region=edge_at(4, 1))
+        self.mesh.boundaries.set_open(region=edge_at(0, 5))
+        self.mesh.boundaries.set_open(region=edge_at(4, 5))
+
+        bdry = self.mesh.boundaries.data
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry[None]), 4)
+        self.assertEqual(len(bdry[0]), 4)
+        self.assertEqual(len(bdry[1]), 1)
+
+        self.assertEqual(bdry[None][0]['indexes'], [1, 2, 3])
+        self.assertEqual(bdry[None][1]['indexes'], [5, 10, 15])
+        self.assertEqual(bdry[None][2]['indexes'], [21, 26, 27])
+        self.assertEqual(bdry[None][3]['indexes'], [29, 30, 25])
+

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -144,6 +144,19 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
+    def test_manual_boundary_notaffect_interior(self):
+        self.mesh.boundaries.auto_generate()
+
+        self.mesh.boundaries.set_open(region=geometry.box(0.5, 1.5, 2.5, 3.5))
+
+        bdry = self.mesh.boundaries
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry.open()), 0)
+        self.assertEqual(len(bdry.land()), 1)
+        self.assertEqual(len(bdry.interior()), 1)
+
+
 
     def test_specified_boundary_order(self):
         edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -157,6 +157,35 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(len(bdry.interior()), 1)
 
 
+    def test_manual_boundary_convex_region(self):
+        self.mesh.boundaries.auto_generate()
+
+        self.mesh.boundaries.set_open(region=geometry.Polygon([
+            (-1, 4.5),
+            (0.5, 4.5),
+            (0.5, 3.5),
+            (-0.5, 3.5),
+            (-0.5, 1.5),
+            (0.5, 1.5),
+            (0.5, 0.5),
+            (-1, 0.5),
+        ]))
+
+        bdry = self.mesh.boundaries
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry.open()), 2)
+        self.assertEqual(len(bdry.land()), 2)
+        self.assertEqual(len(bdry.interior()), 1)
+
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 6, 11])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [16, 21, 26])
+        self.assertEqual(bdry.land().iloc[0]['index_id'], [11, 16])
+        self.assertEqual(
+            bdry.land().iloc[1]['index_id'],
+            [26, 27, 28, 29, 30, 25, 20, 15, 10, 5, 4, 3, 2, 1]
+        )
+
 
     def test_specified_boundary_order(self):
         edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -69,14 +69,14 @@ class BoundaryExtraction(unittest.TestCase):
         )
 
         self.mesh = Mesh(mesh_msht)
-                
+
 
     def test_auto_boundary_fails_if_na_elev(self):
         # Set one node to nan value
         self.mesh.msh_t.value[-1] = np.nan
         with self.assertRaises(ValueError):
             self.mesh.boundaries.auto_generate()
-        
+
 
     def test_auto_boundary_1open_correctness(self):
         # Set right boundary to be open
@@ -262,25 +262,23 @@ class BoundaryExtraction(unittest.TestCase):
         # bdry is referring to mesh object and can be mutated
         bdry = self.mesh.boundaries
 
-        # No merge -> order of specifying
-        self.mesh.boundaries.set_open(region=edge_at(3, 0))
+        self.mesh.boundaries.set_open(region=edge_at(1, 0))
+        self.mesh.boundaries.set_open(region=edge_at(4, 1))
         self.mesh.boundaries.set_open(region=edge_at(0, 5))
+        self.mesh.boundaries.set_open(region=edge_at(4, 5))
+        self.mesh.boundaries.set_open(region=edge_at(4, 4))
+        self.mesh.boundaries.set_open(region=edge_at(0, 0), merge=True)
+        self.mesh.boundaries.set_open(region=edge_at(0, 4), merge=True)
 
-        self.assertEqual(len(bdry.open()), 2)
-        self.assertEqual(len(bdry.land()), 2)
+        bdry = self.mesh.boundaries
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry.open()), 4)
+        self.assertEqual(len(bdry.land()), 4)
         self.assertEqual(len(bdry.interior()), 1)
 
-        self.assertEqual(bdry.open().iloc[0]['index_id'], [3, 4, 5])
-        self.assertEqual(bdry.open().iloc[1]['index_id'], [21, 26, 27])
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [6, 1, 2, 3])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [5, 10, 15])
+        self.assertEqual(bdry.open().iloc[2]['index_id'], [16, 21, 26, 27])
+        self.assertEqual(bdry.open().iloc[3]['index_id'], [20, 25, 30, 29])
 
-
-        # With merge -> reorder based on X then Y of line coords
-        self.mesh.boundaries.set_open(region=edge_at(0, 2), merge=True)
-
-        self.assertEqual(len(bdry.open()), 3)
-        self.assertEqual(len(bdry.land()), 3)
-        self.assertEqual(len(bdry.interior()), 1)
-
-        self.assertEqual(bdry.open().iloc[0]['index_id'], [6, 11, 16])
-        self.assertEqual(bdry.open().iloc[1]['index_id'], [21, 26, 27])
-        self.assertEqual(bdry.open().iloc[2]['index_id'], [3, 4, 5])

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -1,6 +1,7 @@
 #! python
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -69,8 +70,12 @@ class BoundaryExtraction(unittest.TestCase):
             vals, dtype=jigsaw_msh_t.REALS_t
         )
 
-        self.mesh = Mesh(mesh_msht)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', category=UserWarning, message='Input mesh has no CRS information'
+            )
 
+            self.mesh = Mesh(mesh_msht)
 
     def test_auto_boundary_fails_if_na_elev(self):
         # Set one node to nan value

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -47,6 +47,7 @@ class BoundaryExtraction(unittest.TestCase):
                     continue
                 cells.append([j * nx + i, j * nx + (i + 1), (j + 1) * nx + i])
                 cells.append([j * nx + (i + 1), (j + 1) * nx + (i + 1), (j + 1) * nx + i])
+        # NOTE: Everywhere is above 0 (auto: land) unless modified later
         vals = np.ones((len(verts), 1)) * 10
 
         # TODO: Replace with "make_mesh" util function
@@ -208,3 +209,16 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry.open().iloc[2]['index_id'], [21, 26, 27])
         self.assertEqual(bdry.open().iloc[3]['index_id'], [29, 30, 25])
 
+
+    def test_manual_boundary_brokenring_stillconnected(self):
+        edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)
+
+        self.mesh.boundaries.auto_generate()
+        self.mesh.boundaries.set_open(region=edge_at(4, 5))
+
+        bdry = self.mesh.boundaries
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry.open()), 1)
+        self.assertEqual(len(bdry.land()), 1)
+        self.assertEqual(len(bdry.interior()), 1)

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -105,7 +105,6 @@ class BoundaryExtraction(unittest.TestCase):
 
         bdry = self.mesh.boundaries
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 2)
         self.assertEqual(len(bdry.land()), 2)
         self.assertEqual(len(bdry.interior()), 1)
@@ -129,7 +128,6 @@ class BoundaryExtraction(unittest.TestCase):
 
         bdry = self.mesh.boundaries
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 2)
         self.assertEqual(len(bdry.land()), 2)
         self.assertEqual(len(bdry.interior()), 1)
@@ -152,7 +150,6 @@ class BoundaryExtraction(unittest.TestCase):
 
         bdry = self.mesh.boundaries
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 0)
         self.assertEqual(len(bdry.land()), 1)
         self.assertEqual(len(bdry.interior()), 1)
@@ -174,7 +171,6 @@ class BoundaryExtraction(unittest.TestCase):
 
         bdry = self.mesh.boundaries
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 2)
         self.assertEqual(len(bdry.land()), 2)
         self.assertEqual(len(bdry.interior()), 1)
@@ -188,7 +184,7 @@ class BoundaryExtraction(unittest.TestCase):
         )
 
 
-    def test_specified_boundary_order(self):
+    def test_specified_boundary_order_nomerge(self):
         edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)
 
         self.mesh.boundaries.auto_generate()
@@ -199,7 +195,6 @@ class BoundaryExtraction(unittest.TestCase):
 
         bdry = self.mesh.boundaries
 
-        # Mesh has one segment of each boundary type
         self.assertEqual(len(bdry.open()), 4)
         self.assertEqual(len(bdry.land()), 4)
         self.assertEqual(len(bdry.interior()), 1)
@@ -222,3 +217,49 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(len(bdry.open()), 1)
         self.assertEqual(len(bdry.land()), 1)
         self.assertEqual(len(bdry.interior()), 1)
+
+
+    def test_manual_boundary_merge_sametype(self):
+        edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)
+
+        self.mesh.boundaries.auto_generate()
+        self.mesh.boundaries.set_land(region=edge_at(1, 0), merge=True)
+        self.mesh.boundaries.set_open(region=edge_at(4, 3), merge=True)
+        self.mesh.boundaries.set_open(region=edge_at(4, 4), merge=True)
+
+        bdry = self.mesh.boundaries
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry.open()), 1)
+        self.assertEqual(len(bdry.land()), 1)
+        self.assertEqual(len(bdry.interior()), 1)
+
+
+    def test_specified_boundary_order_withmerge(self):
+        edge_at = lambda x, y: geometry.Point(x, y).buffer(0.05)
+
+        # No merge -> order of specifying
+        self.mesh.boundaries.auto_generate()
+        self.mesh.boundaries.set_open(region=edge_at(3, 0))
+        self.mesh.boundaries.set_open(region=edge_at(0, 5))
+
+        bdry = self.mesh.boundaries
+
+        self.assertEqual(len(bdry.open()), 2)
+        self.assertEqual(len(bdry.land()), 2)
+        self.assertEqual(len(bdry.interior()), 1)
+
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [3, 4, 5])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [21, 26, 27])
+
+
+        # With merge -> reorder based on X then Y of line coords
+        self.mesh.boundaries.set_open(region=edge_at(0, 2), merge=True)
+
+        self.assertEqual(len(bdry.open()), 3)
+        self.assertEqual(len(bdry.land()), 3)
+        self.assertEqual(len(bdry.interior()), 1)
+
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [6, 11, 16])
+        self.assertEqual(bdry.open().iloc[1]['index_id'], [21, 26, 27])
+        self.assertEqual(bdry.open().iloc[2]['index_id'], [3, 4, 5])

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -1,0 +1,109 @@
+#! python
+import unittest
+from pathlib import Path
+
+import numpy as np
+from jigsawpy import jigsaw_msh_t
+
+from ocsmesh.mesh.mesh import Mesh
+
+class BoundaryExtraction(unittest.TestCase):
+
+    def setUp(self):
+        """
+        index(id):
+
+          0(1)               4(5)
+            *---*---*---*---*
+            | / | / | / | / |
+            *---*---*---*---*
+            | / | / | / | / |
+            *---*---*---*---*
+            | / |   | / | / |
+            *---*---*---*---*
+            | / | / | / | / |
+            *---*---*---*---*
+            | / | / | / | / |
+            *---*---*---*---*
+          20(21)             29(30)
+        """
+
+        # Create a basic grid with a hole
+        nx, ny = 5, 6
+        hole_square = 10
+        X, Y = np.meshgrid(range(nx), range(ny))
+        verts = np.array(list(zip(X.ravel(), Y.ravel())))
+        cells = []
+        for j in range(ny - 1):
+            for i in range(nx - 1):
+                if (i + 1) + ((nx-1) * j) == hole_square:
+                    continue
+                cells.append([j * nx + i, j * nx + (i + 1), (j + 1) * nx + i])
+                cells.append([j * nx + (i + 1), (j + 1) * nx + (i + 1), (j + 1) * nx + i])
+        vals = np.ones((len(verts), 1)) * 10
+
+        mesh_msht = jigsaw_msh_t()
+        mesh_msht.ndims = +2
+        mesh_msht.mshID = 'euclidean-mesh'
+        mesh_msht.tria3 = np.array(
+            [(c, 0) for c in cells], dtype=jigsaw_msh_t.TRIA3_t
+        )
+        mesh_msht.vert2 = np.array(
+            [(v, 0) for v in verts], dtype=jigsaw_msh_t.VERT2_t
+        )
+        mesh_msht.value = np.array(
+            vals, dtype=jigsaw_msh_t.REALS_t
+        )
+
+        self.mesh = Mesh(mesh_msht)
+                
+
+    def test_auto_boundary_fails_if_na_elev(self):
+        # Set one node to nan value
+        self.mesh.msh_t.value[-1] = np.nan
+        with self.assertRaises(ValueError):
+            self.mesh.boundaries.auto_generate()
+        
+
+    def test_auto_boundary_1ocean_correctness(self):
+        # Set right boundary to be ocean
+        self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] > 3] = -10
+
+        self.mesh.boundaries.auto_generate()
+
+        bdry = self.mesh.boundaries.data
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry[None]), 1)
+        self.assertEqual(len(bdry[0]), 1)
+        self.assertEqual(len(bdry[1]), 1)
+
+        # Counter-clockwise boundaries node ID list
+        self.assertEqual(bdry[None][0]['indexes'], [30, 25, 20, 15, 10, 5])
+        self.assertEqual(
+            bdry[0][0]['indexes'],
+            [5, 4, 3, 2, 1, 6, 11, 16, 21, 26, 27, 28, 29, 30]
+        )
+        self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
+
+
+    def test_auto_boundary_2oceans_correctness(self):
+        # Set left and right boundary to be ocean
+        self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] > 3] = -10
+        self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] < 1] = -10
+
+        self.mesh.boundaries.auto_generate()
+
+        bdry = self.mesh.boundaries.data
+
+        # Mesh has one segment of each boundary type
+        self.assertEqual(len(bdry[None]), 2)
+        self.assertEqual(len(bdry[0]), 2)
+        self.assertEqual(len(bdry[1]), 1)
+
+        # Counter-clockwise boundaries node ID list
+        self.assertEqual(bdry[None][0]['indexes'], [1, 6, 11, 16, 21, 26])
+        self.assertEqual(bdry[None][1]['indexes'], [30, 25, 20, 15, 10, 5])
+        self.assertEqual(bdry[0][0]['indexes'], [5, 4, 3, 2, 1])
+        self.assertEqual(bdry[0][1]['indexes'], [26, 27, 28, 29, 30])
+        self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -72,8 +72,8 @@ class BoundaryExtraction(unittest.TestCase):
             self.mesh.boundaries.auto_generate()
         
 
-    def test_auto_boundary_1ocean_correctness(self):
-        # Set right boundary to be ocean
+    def test_auto_boundary_1open_correctness(self):
+        # Set right boundary to be open
         self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] > 3] = -10
 
         self.mesh.boundaries.auto_generate()
@@ -94,8 +94,8 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry[1][0]['indexes'], [12, 13, 18, 17, 12])
 
 
-    def test_auto_boundary_2oceans_correctness(self):
-        # Set left and right boundary to be ocean
+    def test_auto_boundary_2open_correctness(self):
+        # Set left and right boundary to be open
         self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] > 3] = -10
         self.mesh.msh_t.value[self.mesh.msh_t.vert2['coord'][:, 0] < 1] = -10
 

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -313,3 +313,17 @@ class BoundaryExtraction(unittest.TestCase):
 
         self.assertEqual(len(bdry.interior()), 1)
         self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+
+
+    def test_specify_boundary_on_mesh_with_no_boundary(self):
+        bdry = self.mesh.boundaries
+
+        with self.assertWarns(UserWarning) as w:
+            bdry.set_open(region=edge_at(1, 0))
+        self.assertTrue('didn\'t have prior boundary' in str(w.warning))
+
+        self.assertEqual(len(bdry.open()), 1)
+        self.assertEqual(len(bdry.land()), 0)
+        self.assertEqual(len(bdry.interior()), 0)
+
+        self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2, 3])


### PR DESCRIPTION
So far OCSMesh only has supported automatic generation of boundary segments (for SCHISM/ADCIRC) based on elevation of the mesh nodes and an input threshold. #59 request for the ability to specify boundaries manually.