### PR TITLE
Add support for non-tria elements in cleanup functions

### DIFF
--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -1597,7 +1597,8 @@ class Boundaries:
 
         ext_bdry_nodes = []
         for ring in self.mesh.hull.rings.exterior().itertuples():
-            # TODO: Enforce external rings to be ccw as https://github.com/noaa-ocs-modeling/OCSMesh/issues/65
+            # TODO: Enforce external rings to be ccw as
+            # https://github.com/noaa-ocs-modeling/OCSMesh/issues/65
             ext_ring_coo = ring.geometry.coords
             ext_ring = np.array([
                     (coo_to_idx[ext_ring_coo[e]],
@@ -2044,8 +2045,7 @@ class Boundaries:
             if this_edge_info is None:
                 warnings.warn(f"Edge boundary {edge} didn't have prior boundary set!")
                 continue
-            else:
-                tp_id, bd_id, ed_idx = this_edge_info
+            tp_id, bd_id, ed_idx = this_edge_info
             splits_idx.setdefault((tp_id, bd_id), []).append(ed_idx)
 
         # Apply splits to the boundary dictionary

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -25,7 +25,13 @@ import geopandas as gpd
 import utm
 
 
+# TODO: Remove one of these two constants
 ELEM_2D_TYPES = ['tria3', 'quad4', 'hexa8']
+MESH_TYPES = {
+    'tria3': 'TRIA3_t',
+    'quad4': 'QUAD4_t',
+    'hexa8': 'HEXA8_t'
+}
 
 def must_be_euclidean_mesh(func):
     def decorator(mesh, *args, **kwargs):
@@ -768,13 +774,8 @@ def select_adjacent(mesh, in_indices, num_layers):
             coord = mesh.vert2['coord']
 
             # TODO: What about edge2
-            mesh_types = {
-                'tria3': 'TRIA3_t',
-                'quad4': 'QUAD4_t',
-                'hexa8': 'HEXA8_t'
-            }
             elm_dict = {
-                key: getattr(mesh, key)['index'] for key in mesh_types}
+                key: getattr(mesh, key)['index'] for key in MESH_TYPES}
 
             mark_func = np.any
 
@@ -958,13 +959,8 @@ def clip_mesh_by_vertex(
         coord = mesh.vert2['coord']
 
         # TODO: What about edge2 if in_place?
-        mesh_types = {
-            'tria3': 'TRIA3_t',
-            'quad4': 'QUAD4_t',
-            'hexa8': 'HEXA8_t'
-        }
         elm_dict = {
-            key: getattr(mesh, key)['index'] for key in mesh_types}
+            key: getattr(mesh, key)['index'] for key in MESH_TYPES}
 
         # Whether elements that include "in"-vertices can be created
         # using vertices other than "in"-vertices
@@ -1027,7 +1023,7 @@ def clip_mesh_by_vertex(
             [(coo, 0) for coo in new_coord],
             dtype=jigsaw_msh_t.VERT2_t)
 
-        for key, elem_type in mesh_types.items():
+        for key, elem_type in MESH_TYPES.items():
             setattr(
                 mesh_out,
                 key,
@@ -1604,14 +1600,8 @@ def merge_msh_t(
 
     dst_crs = CRS.from_user_input(out_crs)
 
-    mesh_types = {
-        'tria3': 'TRIA3_t',
-        'quad4': 'QUAD4_t',
-        'hexa8': 'HEXA8_t'
-    }
-
     coord = []
-    elems = {k: [] for k in mesh_types}
+    elems = {k: [] for k in MESH_TYPES}
     value = []
     offset = 0
 
@@ -1643,7 +1633,7 @@ def merge_msh_t(
         mesh_shape_list.append(mesh_shape)
 
 
-        for k in mesh_types:
+        for k in MESH_TYPES:
             cnn = getattr(mesh, k)
             elems[k].append(cnn['index'] + offset)
         coord.append(mesh.vert2['coord'])
@@ -1660,7 +1650,7 @@ def merge_msh_t(
     composite_mesh.value = np.array(
             np.vstack(value),
             dtype=jigsaw_msh_t.REALS_t)
-    for k, v in mesh_types.items():
+    for k, v in MESH_TYPES.items():
         setattr(composite_mesh, k, np.array(
             [(cnn, 0) for cnn in np.vstack(elems[k])],
             dtype=getattr(jigsaw_msh_t, v)))

--- a/tests/api/driver.py
+++ b/tests/api/driver.py
@@ -16,7 +16,6 @@ import ocsmesh
 
 from tests.api.common import (
     raster_from_numpy,
-    msht_from_numpy,
     create_rectangle_mesh,
     topo_2rast_1mesh,
 )

--- a/tests/api/geom.py
+++ b/tests/api/geom.py
@@ -16,7 +16,6 @@ import ocsmesh
 
 from tests.api.common import (
     raster_from_numpy,
-    msht_from_numpy,
     create_rectangle_mesh,
     topo_2rast_1mesh,
 )

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -656,7 +656,7 @@ class SizeFunctionCollectorAddFeature(unittest.TestCase):
             [0, 2, 6],
             [5, 4, 7],
         ])
-        msh_t = msht_from_numpy(crd, tria, 4326)
+        msh_t = msht_from_numpy(crd, tria, crs=4326)
         mesh = ocsmesh.Mesh(msh_t)
         mesh.write(str(self.mesh1), format='grd', overwrite=False)
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -22,14 +22,20 @@ from tests.api.common import (
 
 class FinalizeMesh(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def test_cleanup_mesh_and_generate_valid_mesh(self):
         msh_t1 = create_rectangle_mesh(
-            nx=40, ny=40, holes=[40, 41], x_extent=(-2, 2), y_extent=(-2, 2))
+            nx=40, ny=40,
+            holes=[50, 51],
+            quads=np.hstack((
+                np.arange(130, 150),
+                np.arange(170, 190),
+            )),
+            x_extent=(-2, 2), y_extent=(-2, 2))
+
         msh_t2 = create_rectangle_mesh(
-            nx=20, ny=20, holes=[], x_extent=(-3.5, -3), y_extent=(0, 1))
+            nx=20, ny=20,
+            holes=[],
+            x_extent=(-3.5, -3), y_extent=(0, 1))
 
         verts = msh_t1.vert2['coord']
         verts = np.vstack((verts, msh_t2.vert2['coord']))
@@ -37,7 +43,10 @@ class FinalizeMesh(unittest.TestCase):
         trias = msh_t1.tria3['index']
         trias = np.vstack((trias, msh_t2.tria3['index'] + len(msh_t1.vert2)))
 
-        msh_t = msht_from_numpy(verts, trias)
+        quads = msh_t1.quad4['index']
+        quads = np.vstack((quads, msh_t2.quad4['index'] + len(msh_t1.vert2)))
+
+        msh_t = msht_from_numpy(verts, trias, quads)
 
         utils.finalize_mesh(msh_t)
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -14,6 +14,33 @@ from shapely.geometry import (
 
 from ocsmesh import utils
 
+from tests.api.common import (
+    create_rectangle_mesh,
+    msht_from_numpy,
+)
+
+
+class FinalizeMesh(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_cleanup_mesh_and_generate_valid_mesh(self):
+        msh_t1 = create_rectangle_mesh(
+            nx=40, ny=40, holes=[40, 41], x_extent=(-2, 2), y_extent=(-2, 2))
+        msh_t2 = create_rectangle_mesh(
+            nx=20, ny=20, holes=[], x_extent=(-3.5, -3), y_extent=(0, 1))
+
+        verts = msh_t1.vert2['coord']
+        verts = np.vstack((verts, msh_t2.vert2['coord']))
+
+        trias = msh_t1.tria3['index']
+        trias = np.vstack((trias, msh_t2.tria3['index'] + len(msh_t1.vert2)))
+
+        msh_t = msht_from_numpy(verts, trias)
+
+        utils.finalize_mesh(msh_t)
+
 
 class RemovePolygonHoles(unittest.TestCase):
 


### PR DESCRIPTION
Right now functions used in `finalize_mesh` function in `utils` doesn't account for non-tria3 elements, which result in corrupt mesh.