### PR TITLE
Improve subsetting by removing out-of-buffer zone elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python ./setup.py develop # Run this if you are a developer.
 ```
 
 #### Requirements
-* 3.7 <= Python < 3.10
+* 3.9 <= Python
 * CMake 
 * C/C++ compilers
 


### PR DESCRIPTION
Sometimes when meshing the buffer zone, due to the geometry shape, Jigsaw might generate out of domain elements. This results in overlapping elements that might or might not be **exactly** matched. If they are not matched, then duplication removal will not detect them and we'll end up with an invalid mesh.

![image](https://github.com/noaa-ocs-modeling/OCSMesh/assets/77082694/9de09503-1fb6-4b27-ba77-6add2fb90adf)
