### PR TITLE
Improve subsetting robustness by using `triangle` for buffer meshing

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,7 +23,7 @@ jobs:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
         extra-specs: |
-          python=3.*
+          python=3.10
     - name: Install dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,8 +22,6 @@ jobs:
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
-        extra-specs: |
-          python=3.10
     - name: Install dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.x']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.x']
+        python-version: [ '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/functional_test_2.yml
+++ b/.github/workflows/functional_test_2.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10' ]
 
     steps:
     - name: Checkout 

--- a/.github/workflows/functional_test_2.yml
+++ b/.github/workflows/functional_test_2.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.x' ]
 
     steps:
     - name: Checkout 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,8 +30,6 @@ jobs:
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
-        extra-specs: |
-          python=3.10
     - name: Install dependencies
       shell: bash -l {0}
       run: |

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -31,7 +31,7 @@ jobs:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
         extra-specs: |
-          python=3.*
+          python=3.10
     - name: Install dependencies
       shell: bash -l {0}
       run: |

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -11,11 +11,12 @@ from jigsawpy.msh_t import jigsaw_msh_t
 from jigsawpy.jig_t import jigsaw_jig_t
 import numpy as np
 from pyproj import CRS, Transformer
+from scipy.interpolate import griddata
 from scipy.spatial import cKDTree
 from shapely.geometry import MultiPolygon, Polygon, GeometryCollection
 from shapely.ops import polygonize, unary_union
 
-from ocsmesh import Raster, Geom, Mesh, Hfun, utils
+from ocsmesh import Raster, Geom, Mesh, Hfun, utils, JigsawDriver
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -242,96 +243,101 @@ class SubsetAndCombine:
 
         return new_polygon, clipped_mesh
 
-    def _calculate_mesh_size_function(self, hires_mesh_clip, lores_mesh_clip, crs):
+    def _calculate_mesh_size_function(
+            self,
+            buffer_domain,
+            hires_mesh_clip,
+            lores_mesh_clip,
+            buffer_crs
+        ):
+
+        assert(buffer_crs == hires_mesh_clip.crs == lores_mesh_clip.crs)
+
+        # HARDCODED FOR NOW
+        approx_elem_per_width = 3
+
+        utm = utils.estimate_bounds_utm(
+            buffer_domain.bounds, buffer_crs
+        )
 
         # calculate mesh size for clipped bits
-        hfun_hires = Hfun(Mesh(deepcopy(hires_mesh_clip)))
-        hfun_hires.size_from_mesh()
-        hfun_lowres = Hfun(Mesh(deepcopy(lores_mesh_clip)))
-        hfun_lowres.size_from_mesh()
+        msht_hi = deepcopy(hires_mesh_clip)
+        utils.reproject(msht_hi, utm)
+        hfun_hi = Hfun(Mesh(msht_hi))
+        hfun_hi.size_from_mesh()
 
-#    _logger.info("Writing hfun clips...")
-#    start = time()
-#    hfun_hires.mesh.write(str(out_dir / "hfun_fine.2dm"), format="2dm", overwrite=True)
-#    hfun_lowres.mesh.write(str(out_dir / "hfun_coarse.2dm"), format="2dm", overwrite=True)
-#    _logger.info(f"Done in {time() - start} sec")
+        msht_lo = deepcopy(lores_mesh_clip)
+        utils.reproject(msht_lo, utm)
+        hfun_lo = Hfun(Mesh(msht_lo))
+        hfun_lo.size_from_mesh()
 
-        jig_hfun = utils.merge_msh_t(
-            hfun_hires.msh_t(), hfun_lowres.msh_t(),
-            out_crs=crs)#jig_geom) ### TODO: CRS MUST BE == GEOM_MSHT CRS
+        msht_cdt = utils.triangulate_polygon(
+            buffer_domain, None, opts='p'
+        )
+        msht_cdt.crs = buffer_crs
 
-        return jig_hfun
+        utils.reproject(msht_cdt, utm)
+        hfun_cdt = Hfun(Mesh(msht_cdt))
+        hfun_cdt.size_from_mesh()
+
+        hfun_cdt_sz = deepcopy(hfun_cdt.msh_t().value) / approx_elem_per_width
+        msht_cdt.value[:] = hfun_cdt_sz 
+        hfun_rep = Hfun(Mesh(msht_cdt))
+
+        mesh_domain_rep = JigsawDriver(
+            geom=Geom(buffer_domain, crs=buffer_crs),
+            hfun=hfun_rep,
+            initial_mesh=False
+        ).run()
+
+        msht_domain_rep = deepcopy(mesh_domain_rep.msh_t)
+        utils.reproject(msht_domain_rep, utm)
+
+        pts_2mesh = np.vstack(
+            (hfun_hi.msh_t().vert2['coord'], hfun_lo.msh_t().vert2['coord'])
+        )
+        val_2mesh = np.vstack(
+            (hfun_hi.msh_t().value, hfun_lo.msh_t().value)
+        )
+        domain_sz_1 = griddata(
+            pts_2mesh, val_2mesh, msht_domain_rep.vert2['coord'], method='linear'
+        )
+        domain_sz_2 = griddata(
+            pts_2mesh, val_2mesh, msht_domain_rep.vert2['coord'], method='nearest'
+        )
+        domain_sz = domain_sz_1.copy()
+        domain_sz[np.isnan(domain_sz_1)] = domain_sz_2[np.isnan(domain_sz_1)]
+
+        msht_domain_rep.value[:] = domain_sz
+        hfun_interp = Hfun(Mesh(msht_domain_rep))
+
+        return hfun_interp
 
 
     def _generate_mesh_for_buffer_region(
-            self, buffer_polygon, jig_hfun, crs):
+            self, buffer_polygon, hfun_buffer, buffer_crs):
 
-        seam = Geom(buffer_polygon, crs=crs)
+        mesh_domain_interp = JigsawDriver(
+            geom=Geom(buffer_polygon, crs=buffer_crs),
+            hfun=hfun_buffer,
+            initial_mesh=False
+        ).run()
 
-        jig_geom = seam.msh_t()
+        msht_domain_interp = deepcopy(mesh_domain_interp.msh_t)
+        in_verts_mask = np.ones_like(msht_domain_interp.vert2, dtype=bool)
+        in_verts_mask[
+            np.unique(utils.get_boundary_edges(msht_domain_interp))
+        ] = False
 
-        # IMPORTANT: Setting these to -1 results in NON CONFORMAL boundary
-#    jig_geom.vert2['IDtag'][:] = -1
-#    jig_geom.edge2['IDtag'][:] = -1
-
-        jig_init = deepcopy(seam.msh_t())
-        jig_init.vert2['IDtag'][:] = -1
-        jig_init.edge2['IDtag'][:] = -1
-
-        # Calculate length of all edges on geom
-        geom_edges = jig_geom.edge2['index']
-        geom_coords = jig_geom.vert2['coord'][geom_edges, :]
-        geom_edg_lens = np.sqrt(np.sum(
-            np.power(np.abs(np.diff(geom_coords, axis=1)), 2),
-            axis=2)).squeeze()
-
-        # TODO: Use marche to calculate mesh size in the area between
-        # the two regions?
-
-        _logger.info("Meshing...")
-        start = time()
-        opts = jigsaw_jig_t()
-        opts.hfun_scal = "absolute"
-        opts.hfun_hmin = np.min(geom_edg_lens)
-        opts.hfun_hmax = np.max(geom_edg_lens)
-#    opts.hfun_hmin = np.min(jig_hfun.value.ravel())
-#    opts.hfun_hmax = np.max(jig_hfun.value.ravel())
-        opts.optm_zip_ = False
-        opts.optm_div_ = False
-        opts.mesh_dims = +2
-        opts.mesh_rad2 = 1.05
-#    opts.mesh_rad2 = 2.0
-
-        jig_mesh = jigsaw_msh_t()
-        jig_mesh.mshID = 'euclidean-mesh'
-        jig_mesh.ndims = 2
-        jig_mesh.crs = jig_geom.crs
-
-        jigsawpy.lib.jigsaw(
-            opts, jig_geom, jig_mesh,
-#        hfun=jig_hfun,
-            init=jig_init
-            )
-
-        jig_mesh.value = np.zeros((jig_mesh.vert2.shape[0], 1))
-        self._transform_mesh(jig_mesh, crs)
-
-        # NOTE: Remove out of domain elements (some corner cases!)
-        elems = jig_mesh.tria3['index']
-        coord = jig_mesh.vert2['coord']
-
-        gdf_elems = gpd.GeoDataFrame(
-            geometry=[Polygon(tri) for tri in coord[elems]],
-            crs=jig_mesh.crs
+        utils.reproject(msht_domain_interp, buffer_crs)
+        msht_buffer = utils.triangulate_polygon(
+            shape=buffer_polygon,
+            aux_pts=msht_domain_interp.vert2[in_verts_mask]['coord'],
+            opts='p'
         )
-        idx = gdf_elems.representative_point().sindex.query(
-            seam.get_multipolygon(), predicate='intersects'
-        )
-        flag = np.zeros(len(gdf_elems), dtype=bool)
-        flag[idx] = True
-        jig_mesh.tria3 = jig_mesh.tria3[flag]
+        msht_buffer.crs = buffer_crs
 
-        return jig_mesh
+        return msht_buffer
 
 
     def _transform_mesh(self, mesh, out_crs):
@@ -623,9 +629,13 @@ class SubsetAndCombine:
 
         poly_seam = poly_seam_8
 
-        # TODO: Get CRS correctly from geom utm
-#    jig_hfun = self._calculate_mesh_size_function(jig_clip_hires, jig_clip_lowres, crs)
-        jig_buffer_mesh = self._generate_mesh_for_buffer_region(poly_seam, None, crs)
+        hfun_buffer = self._calculate_mesh_size_function(
+            poly_seam, jig_clip_hires, jig_clip_lowres, crs
+        )
+        jig_buffer_mesh = self._generate_mesh_for_buffer_region(
+            poly_seam, hfun_buffer, crs
+        )
+        # TODO: UTM TO CRS?
 
         _logger.info("Combining meshes...")
         start = time()

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -345,6 +345,8 @@ class SubsetAndCombine:
         )
         msht_buffer.crs = utm
 
+        utils.reproject(msht_buffer, buffer_crs)
+
         return msht_buffer
 
 

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -6,9 +6,7 @@ import sys
 from time import time
 
 import geopandas as gpd
-import jigsawpy
 from jigsawpy.msh_t import jigsaw_msh_t
-from jigsawpy.jig_t import jigsaw_jig_t
 import numpy as np
 from pyproj import CRS, Transformer
 from scipy.interpolate import griddata
@@ -251,7 +249,7 @@ class SubsetAndCombine:
             buffer_crs
         ):
 
-        assert(buffer_crs == hires_mesh_clip.crs == lores_mesh_clip.crs)
+        assert buffer_crs == hires_mesh_clip.crs == lores_mesh_clip.crs
 
         # HARDCODED FOR NOW
         approx_elem_per_width = 3
@@ -283,7 +281,7 @@ class SubsetAndCombine:
         hfun_cdt.size_from_mesh()
 
         hfun_cdt_sz = deepcopy(hfun_cdt.msh_t().value) / approx_elem_per_width
-        msht_cdt.value[:] = hfun_cdt_sz 
+        msht_cdt.value[:] = hfun_cdt_sz
         hfun_rep = Hfun(Mesh(msht_cdt))
 
         mesh_domain_rep = JigsawDriver(
@@ -332,10 +330,10 @@ class SubsetAndCombine:
         ).run(sieve=0)
 
         msht_buf_apprx = deepcopy(mesh_buf_apprx.msh_t)
-        # If vertices are too close to buffer geom boundary, 
+        # If vertices are too close to buffer geom boundary,
         # it's going to cause issues (thin elements)
         if msht_buf_apprx.crs != hfun_buffer.crs:
-            ocsmesh.utils.reproject(msht_buf_apprx, hfun_buffer.crs)
+            utils.reproject(msht_buf_apprx, hfun_buffer.crs)
         gdf_pts = gpd.GeoDataFrame(
             geometry=[MultiPoint(msht_buf_apprx.vert2['coord'])],
             crs=msht_buf_apprx.crs

--- a/ocsmesh/cli/subset_n_combine.py
+++ b/ocsmesh/cli/subset_n_combine.py
@@ -290,7 +290,7 @@ class SubsetAndCombine:
             geom=Geom(buffer_domain, crs=utm),
             hfun=hfun_rep,
             initial_mesh=False
-        ).run()
+        ).run(sieve=0)
 
         msht_domain_rep = deepcopy(mesh_domain_rep.msh_t)
         utils.reproject(msht_domain_rep, utm)
@@ -329,7 +329,7 @@ class SubsetAndCombine:
             geom=Geom(buffer_polygon, crs=utm),
             hfun=hfun_buffer,
             initial_mesh=False
-        ).run()
+        ).run(sieve=0)
 
         msht_domain_interp = deepcopy(mesh_domain_interp.msh_t)
         in_verts_mask = np.ones_like(msht_domain_interp.vert2, dtype=bool)

--- a/ocsmesh/geom/base.py
+++ b/ocsmesh/geom/base.py
@@ -144,42 +144,8 @@ def multipolygon_to_jigsaw_msh_t(
         transformer = Transformer.from_crs(crs, utm_crs, always_xy=True)
         multipolygon = ops.transform(transformer.transform, multipolygon)
 
-    vert2: List[Tuple[Tuple[float, float], int]] = []
-    for polygon in multipolygon.geoms:
-        if np.all(
-                np.asarray(
-                    polygon.exterior.coords).flatten() == float('inf')):
-            raise NotImplementedError("ellispoidal-mesh")
-        for x, y in polygon.exterior.coords[:-1]:
-            vert2.append(((x, y), 0))
-        for interior in polygon.interiors:
-            for x, y in interior.coords[:-1]:
-                vert2.append(((x, y), 0))
-
-    # edge2
-    edge2: List[Tuple[int, int]] = []
-    for polygon in multipolygon.geoms:
-        polygon = [polygon.exterior, *polygon.interiors]
-        for linear_ring in polygon:
-            _edge2 = []
-            for i in range(len(linear_ring.coords)-2):
-                _edge2.append((i, i+1))
-            _edge2.append((_edge2[-1][1], _edge2[0][0]))
-            edge2.extend(
-                [(e0+len(edge2), e1+len(edge2))
-                    for e0, e1 in _edge2])
-    # geom
-    geom = jigsaw_msh_t()
-    geom.ndims = +2
-    geom.mshID = 'euclidean-mesh'
-    # TODO: Consider ellipsoidal case.
-    # geom.mshID = 'euclidean-mesh' if self._ellipsoid is None \
-    #     else 'ellipsoidal-mesh'
-    geom.vert2 = np.asarray(vert2, dtype=jigsaw_msh_t.VERT2_t)
-    geom.edge2 = np.asarray(
-        [((e0, e1), 0) for e0, e1 in edge2],
-        dtype=jigsaw_msh_t.EDGE2_t)
-    geom.crs = crs
+    msht = utils.shape_to_msh_t(multipolygon)
+    msht.crs = crs
     if utm_crs is not None:
-        geom.crs = utm_crs
-    return geom
+        msht.crs = utm_crs
+    return msht

--- a/ocsmesh/geom/base.py
+++ b/ocsmesh/geom/base.py
@@ -2,10 +2,9 @@
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Any, Union
+from typing import Any, Union
 
 from jigsawpy import jigsaw_msh_t
-import numpy as np
 from pyproj import CRS, Transformer
 from shapely import ops
 from shapely.geometry import MultiPolygon

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -383,10 +383,11 @@ class HfunRaster(BaseHfun, Raster):
                 transformer = Transformer.from_crs(
                     self.crs, utm_crs, always_xy=True)
                 bbox = [
-                    *[(x, left[0]) for x in bottom],
-                    *[(bottom[-1], y) for y in reversed(right)],
-                    *[(x, right[-1]) for x in reversed(top)],
-                    *[(bottom[0], y) for y in reversed(left)]]
+                    *[(x, left[0]) for x in bottom][:-1],
+                    *[(bottom[-1], y) for y in right][:-1],
+                    *[(x, right[-1]) for x in reversed(top)][:-1],
+                    *[(bottom[0], y) for y in reversed(left)][:-1]
+                ]
                 geom = PolygonGeom(
                     ops.transform(transformer.transform, Polygon(bbox)),
                     utm_crs

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2137,7 +2137,10 @@ def msht_from_numpy(
             np.zeros((len(mesh.vert2), 1)),
             dtype=jigsaw_msh_t.REALS_t
         )
-    elif values.shape != (len(mesh.vert2), 1):
+    elif not isinstance(values, np.ndarray):
+        values = np.array(values).reshape(-1, 1)
+
+    if values.shape != (len(mesh.vert2), 1):
         raise ValueError(
             "Input for mesh values must either be None or a"
             " 2D-array with row count equal to vertex count!"

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2339,11 +2339,14 @@ def triangulate_polygon(
 
 
     if aux_pts is not None:
-        if isinstance(aux_pts, (gpd.GeoDataFrame, gpd.GeoSeries)):
-            aux_pts = np.array(aux_pts.unary_union.xy).T
+        if isinstance(aux_pts, (Point, MultiPolygon)):
+            aux_pts = gpd.GeoSeries(aux_pts)
+        elif isinstance(aux_pts, gpd.GeoDataFrame):
+            aux_pts = aux_pts.geometry
+        elif not isinstance(aux_pts, gpd.GeoSeries):
+            raise ValueError("Wrong input type for <aux_pts>!")
 
-        elif isinstance(aux_pts, (Point, MultiPolygon)):
-            aux_pts = np.array(aux_pts.xy).T
+        aux_pts = aux_pts.get_coordinates().values
 
         coords = np.vstack((coords, aux_pts))
 

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -200,7 +200,11 @@ def get_mesh_polygons(mesh):
             [Polygon(mesh.vert2['coord'][cell]) for cell in elems]
         )
 
-    return unary_union(elm_polys)
+    poly = unary_union(elm_polys)
+    if isinstance(poly, Polygon):
+        poly = MultiPolygon([poly])
+
+    return poly
 
 
 def repartition_features(linestring, max_verts):

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -1046,7 +1046,7 @@ def get_mesh_edges(mesh: jigsaw_msh_t, unique=True):
                         (elm_type, np.roll(elm_type, shift=1, axis=1)),
                         axis=2),
                     axis=2)
-            edges = edges.reshape(np.product(edges.shape[0:2]), 2)
+            edges = edges.reshape(np.prod(edges.shape[0:2]), 2)
             all_edges = np.vstack((all_edges, edges))
 
     if unique:

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2419,5 +2419,8 @@ def triangulate_polygon(
         values=np.zeros((len(cdt['vertices']) ,1)),
         crs=None,
     )
+    if aux_pts is not None:
+        # To make sure unused points are discarded
+        cleanup_isolates(msht_tri)
 
     return msht_tri

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2363,7 +2363,9 @@ def triangulate_polygon(
 
 
     if aux_pts is not None:
-        if isinstance(aux_pts, (Point, MultiPolygon)):
+        if isinstance(aux_pts, (np.ndarray, list, tuple)):
+            aux_pts = MultiPoint(aux_pts)
+        if isinstance(aux_pts, (Point, MultiPoint)):
             aux_pts = gpd.GeoSeries(aux_pts)
         elif isinstance(aux_pts, gpd.GeoDataFrame):
             aux_pts = aux_pts.geometry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "jigsawpy", "matplotlib", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
     "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "scipy",
-    "shapely>=2", "triangle", "typing_extensions", "utm",
+    "shapely", "triangle", "typing_extensions", "utm",
     ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 description = "Package to generate computational unstructured meshes from planetary modeling."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = '>=3.9' # 3.8 not supported by scipy
+requires-python = '>=3.9, <3.11' # 3.8 -> scipy, 3.11 -> triangle
 dependencies = [
     "colored-traceback", "fiona", "geopandas",
     "jigsawpy", "matplotlib", "netCDF4", "numba",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 description = "Package to generate computational unstructured meshes from planetary modeling."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = '>=3.9, <3.11' # 3.8 -> scipy, 3.11 -> triangle
+requires-python = '>=3.9' # 3.8 -> scipy
 dependencies = [
     "colored-traceback", "fiona", "geopandas",
     "jigsawpy", "matplotlib", "netCDF4", "numba",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "jigsawpy", "matplotlib", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
     "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "scipy",
-    "shapely", "typing_extensions", "utm",
+    "shapely", "triangle", "typing_extensions", "utm",
     ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "jigsawpy", "matplotlib", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
     "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "scipy",
-    "shapely", "triangle", "typing_extensions", "utm",
+    "shapely>=2", "triangle", "typing_extensions", "utm",
     ]
 dynamic = ["version"]
 

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -678,7 +678,9 @@ class SizeFunctionCollectorAddFeature(unittest.TestCase):
             [0, 2, 6],
             [5, 4, 7],
         ])
-        msh_t = ocsmesh.utils.msht_from_numpy(crd, tria, crs=4326)
+        msh_t = ocsmesh.utils.msht_from_numpy(
+            crd, triangles=tria, crs=4326
+        )
         mesh = ocsmesh.Mesh(msh_t)
         mesh.write(str(self.mesh1), format='grd', overwrite=False)
 

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -483,8 +483,8 @@ class SizeFromMesh(unittest.TestCase):
         hfun_calc_val = hfun_calc_jig.value
         hfun_val_diff = self.hfun_orig_val - hfun_calc_val
 
-        # TODO: Come up with a more robust criteria
-        threshold = 0.2
+        # TODO: Come up with a more robust criteria!
+        threshold = 0.21
         err_value = np.max(np.abs(hfun_val_diff))/np.max(self.hfun_orig_val)
         self.assertTrue(err_value < threshold)
 

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -53,6 +53,18 @@ class BoundaryExtraction(unittest.TestCase):
 
             self.mesh = Mesh(mesh_msht)
 
+    def _chkEqualPermutations(self, a, b):
+        # Make sure there are rings!
+        assert a[0] == a[-1] and b[0] == b[-1]
+
+        a = np.array(a[:-1])
+        b = np.array(b[:-1])
+        idx = np.nonzero(a == b[0])
+        if len(idx) == 0:
+            raise ValueError("One item in arg2 is not found in arg1")
+        shift = -idx[0].item()
+        self.assertTrue(np.all(np.roll(a, shift=shift) == np.array(b)))
+
     def test_auto_boundary_fails_if_na_elev(self):
         # Set one node to nan value
         self.mesh.msh_t.value[-1] = np.nan
@@ -79,7 +91,7 @@ class BoundaryExtraction(unittest.TestCase):
             bdry.land().iloc[0]['index_id'],
             [5, 4, 3, 2, 1, 6, 11, 16, 21, 26, 27, 28, 29, 30]
         )
-        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+        self._chkEqualPermutations(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_auto_boundary_2open_correctness(self):
@@ -100,7 +112,7 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(bdry.open().iloc[1]['index_id'], [30, 25, 20, 15, 10, 5])
         self.assertEqual(bdry.land().iloc[0]['index_id'], [5, 4, 3, 2, 1])
         self.assertEqual(bdry.land().iloc[1]['index_id'], [26, 27, 28, 29, 30])
-        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+        self._chkEqualPermutations(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_manual_boundary_specification_correctness(self):
@@ -127,7 +139,7 @@ class BoundaryExtraction(unittest.TestCase):
             [1, 6, 11, 16, 21, 26, 27, 28, 29, 30, 25, 20, 15, 10, 5]
         )
         self.assertEqual(bdry.land().iloc[1]['index_id'], [2, 3, 4])
-        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+        self._chkEqualPermutations(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_manual_boundary_notaffect_interior(self):
@@ -288,7 +300,7 @@ class BoundaryExtraction(unittest.TestCase):
         bdry.find_islands()
 
         self.assertEqual(len(bdry.interior()), 1)
-        self.assertEqual(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
+        self._chkEqualPermutations(bdry.interior().iloc[0]['index_id'], [12, 13, 18, 17, 12])
 
 
     def test_specify_boundary_on_mesh_with_no_boundary(self):
@@ -303,3 +315,7 @@ class BoundaryExtraction(unittest.TestCase):
         self.assertEqual(len(bdry.interior()), 0)
 
         self.assertEqual(bdry.open().iloc[0]['index_id'], [1, 2, 3])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -67,7 +67,9 @@ class FinalizeMesh(unittest.TestCase):
         quads = msh_t1.quad4['index']
         quads = np.vstack((quads, msh_t2.quad4['index'] + len(msh_t1.vert2)))
 
-        msh_t = utils.msht_from_numpy(verts, trias, quads)
+        msh_t = utils.msht_from_numpy(
+            verts, triangles=trias, quadrilaterals=quads
+        )
 
         utils.finalize_mesh(msh_t)
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -590,6 +590,16 @@ class CreateMeshTFromNumpy(unittest.TestCase):
 
         self.assertEqual(out_msht_2.crs, CRS.from_user_input('esri:102008'))
 
+    def test_values(self):
+        # Test it has values
+        # Test value input of wrong size
+        # Test value None input
+        self.assertTrue(False)
+
+
+    def test_kwonly_args(self):
+        self.assertTrue(False)
+
 
 class CreateRasterFromNumpy(unittest.TestCase):
 
@@ -653,6 +663,49 @@ class CreateRasterFromNumpy(unittest.TestCase):
 
             rast = Raster(tf.name)
             self.assertEqual(rast.src.nodata, fill_value)
+
+
+class ShapeToMeshT(unittest.TestCase):
+
+    def test_input_output_types(self):
+        self.assertTrue(False)
+
+
+    def test_old_implementation(self):
+        self.assertTrue(False)
+
+
+    def test_new_implementation(self):
+        self.assertTrue(False)
+
+
+
+
+class TestTriangulatePolygon(unittest.TestCase):
+
+
+    def test_different_input_types(self):
+        self.assertTrue(False)
+
+
+    def test_wrong_input_of_right_type(self):
+        self.assertTrue(False)
+
+
+    def test_output_types(self):
+        self.assertTrue(False)
+
+
+    def test_fixed_boundary(self):
+        self.assertTrue(False)
+
+
+    def test_aux_points(self)
+        self.assertTrue(False)
+
+
+    def test_polygon_holes(self)
+        self.assertTrue(False)
 
 
 if __name__ == '__main__':

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1033,7 +1033,7 @@ class TriangulatePolygon(unittest.TestCase):
 
 
 class GetMeshPolygon(unittest.TestCase):
-    def test_something(self):
+    def test_always_returns_multipolygon(self):
         self.assertTrue(False)
 
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1060,9 +1060,22 @@ class TriangulatePolygon(unittest.TestCase):
 
 class GetMeshPolygon(unittest.TestCase):
     def test_always_returns_multipolygon(self):
-        self.assertTrue(False)
+        poly1 = Polygon(
+            [[0, 0], [0, 4], [6, 4], [6, 0], [4, 2], [2, 2], [0, 0]],
+        )
+        poly2 = Polygon(
+            [[0, 0], [0, -4], [6, -4], [6, 0], [4, -2], [2, -2], [0, 0]],
+        )
+        multpoly = MultiPolygon([poly1, poly2])
 
+        msht_1 = utils.triangulate_polygon(poly1, opts='p')
+        msht_2 = utils.triangulate_polygon(multpoly, opts='p')
 
+        mesh_poly_1 = utils.get_mesh_polygons(msht_1)
+        mesh_poly_2 = utils.get_mesh_polygons(msht_2)
+
+        self.assertIsInstance(mesh_poly_1, MultiPolygon)
+        self.assertIsInstance(mesh_poly_2, MultiPolygon)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -597,10 +597,12 @@ class CreateMeshTFromNumpy(unittest.TestCase):
         # Test value input of wrong size
         # Test value None input
         self.assertTrue(False)
+        #TODO:
 
 
     def test_kwonly_args(self):
         self.assertTrue(False)
+        #TODO:
 
 
 class CreateRasterFromNumpy(unittest.TestCase):
@@ -960,6 +962,8 @@ class TriangulatePolygon(unittest.TestCase):
         msht = utils.triangulate_polygon(bx)
         bdry_lines = utils.get_boundary_segments(msht)
 
+        # TODO: Make sure equal means equal in all vertices, not just
+        # combined shape (i.e. no edge split)
         self.assertTrue(
             list(polygonize(bdry_lines))[0].equals(bx)
         )
@@ -1014,17 +1018,22 @@ class TriangulatePolygon(unittest.TestCase):
         self.assertTrue(mpoly.equals(mesh_poly))
 
 
+    def test_polygons_touching_two_points_no_hole(self):
+        poly1 = Polygon(
+            [[0, 0], [0, 4], [6, 4], [6, 0], [4, 2], [2, 2], [0, 0]],
+        )
+        poly2 = Polygon(
+            [[0, 0], [0, -4], [6, -4], [6, 0], [4, -2], [2, -2], [0, 0]],
+        )
+        multpoly = MultiPolygon([poly1, poly2])
+        msht = utils.triangulate_polygon(multpoly, opts='p')
+        mesh_poly = utils.get_mesh_polygons(msht)
+
+        self.assertTrue(multpoly.equals(mesh_poly))
 
 
-class MeshTFromNumpy(unittest.TestCase):
-
-    def test_io_validity(self):
-        self.assertTrue(False)
-
-    def test_values(self):
-        self.assertTrue(False)
-
-    def test_crs(self):
+class GetMeshPolygon(unittest.TestCase):
+    def test_something(self):
         self.assertTrue(False)
 
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -592,17 +592,43 @@ class CreateMeshTFromNumpy(unittest.TestCase):
 
         self.assertEqual(out_msht_2.crs, CRS.from_user_input('esri:102008'))
 
-    def test_values(self):
-        # Test it has values
-        # Test value input of wrong size
-        # Test value None input
-        self.assertTrue(False)
-        #TODO:
+    def test_values_are_assigned(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            crs=None
+        )
+
+        self.assertTrue(len(out_msht.value) == len(self.in_verts))
+        self.assertTrue(np.all(out_msht.value == 0))
+
+    def test_values_input_validation(self):
+        with self.assertRaises(ValueError) as exc_1:
+            utils.msht_from_numpy(
+                coordinates=self.in_verts,
+                triangles=self.in_tria,
+                values=[1,2,3],
+                crs=None
+            )
+
+        self.assertIsNotNone(
+            re.search(
+                'values must either be',
+                str(exc_1.exception).lower()
+            ),
+        )
 
 
     def test_kwonly_args(self):
-        self.assertTrue(False)
-        #TODO:
+        with self.assertRaises(Exception) as exc_1:
+            utils.msht_from_numpy(self.in_verts, self.in_tria)
+
+        self.assertIsNotNone(
+            re.search(
+                'takes 1 positional argument',
+                str(exc_1.exception).lower()
+            ),
+        )
 
 
 class CreateRasterFromNumpy(unittest.TestCase):


### PR DESCRIPTION
Need to pin python to `3.11` due to issues with building current version `#57d988f (tag: v20220202)` of [triangle](https://github.com/drufat/triangle).

The fix is already in the package, but they just need to release it to PyPI .

**Update**
A new version of `triangle` is not released on PyPI, so no need to pin to pre `3.11` python