### PR TITLE
Fixing Permission Issues on Windows Related to Tempfiles

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -41,13 +41,6 @@ jobs:
         extra-specs: |
           python=${{ matrix.python-version }}
 
-    - name: Install other dependencies
-      shell: bash -l {0}
-      run: |
-        pip install packaging # jigsaw dependency in its setup.py
-        python ./setup.py install_jigsaw
-        pip install .
-
     - name: Prepare example DEM
       if: runner.os == 'Windows'
       shell: bash -l {0}

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -53,10 +53,12 @@ jobs:
         gdalwarp -tr 0.0005 0.0005 -r average -overwrite /tmp/fullsize_dem.tif /tmp/test_dem.tif
 
     - name: Export Conda environment
+      if: runner.os != 'Windows'
       shell: bash -el {0}
       run: conda list > environment_py${{ matrix.python-version }}.yml
 
     - name: 'Upload conda environment'
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: conda-environment-${{ matrix.python-version }}

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -41,8 +41,12 @@ jobs:
         extra-specs: |
           python=${{ matrix.python-version }}
 
+    - name: Install other dependencies
+      shell: bash -l {0}
+      run: pip install .
+
     - name: Prepare example DEM
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       shell: bash -l {0}
       run: |
         wget https://coast.noaa.gov/htdata/raster2/elevation/NCEI_ninth_Topobathy_2014_8483/northeast_sandy/ncei19_n40x75_w073x75_2015v1.tif -O /tmp/fullsize_dem.tif
@@ -61,7 +65,7 @@ jobs:
 
 
     - name: 'Upload test dem'
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: test-dem-${{ matrix.python-version }}
@@ -69,12 +73,12 @@ jobs:
         retention-days: 7
 
     - name: Run geom build test
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       shell: bash -l {0}
       run: source tests/cli/build_geom.sh
 
     - name: 'Upload Geom build results'
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: geom-build-results-${{ matrix.python-version }}
@@ -82,12 +86,12 @@ jobs:
         retention-days: 7
 
     - name: Run hfun build test
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       shell: bash -l {0}
       run: source tests/cli/build_hfun.sh
 
     - name: 'Upload Hfun build results'
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: hfun-build-results-${{ matrix.python-version }}
@@ -95,12 +99,12 @@ jobs:
         retention-days: 7
 
     - name: Run remesh test
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       shell: bash -l {0}
       run: source tests/cli/remesh_by_dem.sh
 
     - name: 'Upload remesh results'
-      if: runner.os == 'Windows'
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: remesh-bydem-results-${{ matrix.python-version }}

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         python-version: [ '3.9', '3.10', '3.11']
 
     steps:
@@ -49,6 +49,7 @@ jobs:
         pip install .
 
     - name: Prepare example DEM
+      if: runner.os == 'Windows'
       shell: bash -l {0}
       run: |
         wget https://coast.noaa.gov/htdata/raster2/elevation/NCEI_ninth_Topobathy_2014_8483/northeast_sandy/ncei19_n40x75_w073x75_2015v1.tif -O /tmp/fullsize_dem.tif
@@ -67,6 +68,7 @@ jobs:
 
 
     - name: 'Upload test dem'
+      if: runner.os == 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: test-dem-${{ matrix.python-version }}
@@ -74,10 +76,12 @@ jobs:
         retention-days: 7
 
     - name: Run geom build test
+      if: runner.os == 'Windows'
       shell: bash -l {0}
       run: source tests/cli/build_geom.sh
 
     - name: 'Upload Geom build results'
+      if: runner.os == 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: geom-build-results-${{ matrix.python-version }}
@@ -85,10 +89,12 @@ jobs:
         retention-days: 7
 
     - name: Run hfun build test
+      if: runner.os == 'Windows'
       shell: bash -l {0}
       run: source tests/cli/build_hfun.sh
 
     - name: 'Upload Hfun build results'
+      if: runner.os == 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: hfun-build-results-${{ matrix.python-version }}
@@ -96,10 +102,12 @@ jobs:
         retention-days: 7
 
     - name: Run remesh test
+      if: runner.os == 'Windows'
       shell: bash -l {0}
       run: source tests/cli/remesh_by_dem.sh
 
     - name: 'Upload remesh results'
+      if: runner.os == 'Windows'
       uses: actions/upload-artifact@v2
       with:
         name: remesh-bydem-results-${{ matrix.python-version }}

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -53,7 +53,7 @@ jobs:
         gdalwarp -tr 0.0005 0.0005 -r average -overwrite /tmp/fullsize_dem.tif /tmp/test_dem.tif
 
     - name: Export Conda environment
-      shell: bash -l {0}
+      shell: bash -el {0}
       run: conda list > environment_py${{ matrix.python-version }}.yml
 
     - name: 'Upload conda environment'
@@ -112,5 +112,5 @@ jobs:
         retention-days: 7
 
     - name: Run Python API tests
-      shell: bash -l {0}
+      shell: bash -el {0}
       run: python -m unittest discover tests/api -p "*.py"

--- a/.github/workflows/functional_test_2.yml
+++ b/.github/workflows/functional_test_2.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.x' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
     - name: Checkout 

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - pytz
   - colored-traceback
   - typing-extensions
+  - jigsawpy

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -832,6 +832,10 @@ class HfunCollector(BaseHfun):
                 rast = self._create_big_raster(temp_dir)
                 hfun = self._apply_features_fast(rast)
                 composite_hfun = self._get_hfun_composite_fast(hfun)
+                # So that the tempfiles are deleted and the dir can be
+                # safely removed
+                del rast
+                del hfun
 
         else:
             raise ValueError(f"Invalid method specified: {self._method}")

--- a/ocsmesh/ops/combine_geom.py
+++ b/ocsmesh/ops/combine_geom.py
@@ -163,16 +163,17 @@ class GeomCombine:
 
         poly_files_coll = []
         _logger.info(f"Number of processes: {nprocs}")
-        with tempfile.TemporaryDirectory(dir=out_dir) as temp_dir, \
-                tempfile.NamedTemporaryFile() as base_file:
+        with tempfile.TemporaryDirectory(dir=out_dir) as temp_dir:
 
+            tmpfd, tmppath = tempfile.mkstemp()
             if base_mult_poly:
-                base_mesh_path = base_file.name
+                base_mesh_path = tmppath
                 self._multipolygon_to_disk(
                     base_mesh_path, base_mult_poly, fix=False)
             else:
                 base_mesh_path = None
             base_mult_poly = None
+            os.close(tmpfd)
 
 
             _logger.info("Processing DEM priorities ...")
@@ -235,6 +236,7 @@ class GeomCombine:
                     ],
                     ignore_index=True
                 )
+            pathlib.Path(tmppath).unlink()
 
 
             # The assumption is this returns polygon or multipolygon

--- a/ocsmesh/raster.py
+++ b/ocsmesh/raster.py
@@ -13,6 +13,7 @@ import os
 import pathlib
 import tempfile
 import warnings
+import platform
 from time import time
 from contextlib import contextmanager, ExitStack
 from typing import (
@@ -144,15 +145,23 @@ class TemporaryFile:
     cleanup capabities on object destruction.
     """
 
-    def __set__(self, obj, val: tempfile.NamedTemporaryFile):
+    def __set__(self, obj, val: Optional[os.PathLike]):
+        tmpfile = obj.__dict__.get('tmpfile')
+        if tmpfile is not None:
+            obj._src = None
+            pathlib.Path(tmpfile).unlink()
+
         obj.__dict__['tmpfile'] = val
-        obj._src = rasterio.open(val.name)
+        if val is None:
+            obj._src = None
+        else:
+            obj._src = rasterio.open(val)
 
     def __get__(self, obj, objtype=None) -> pathlib.Path:
         tmpfile = obj.__dict__.get('tmpfile')
         if tmpfile is None:
             return obj.path
-        return pathlib.Path(tmpfile.name)
+        return pathlib.Path(tmpfile)
 
 
 class SourceRaster:
@@ -165,7 +174,10 @@ class SourceRaster:
     opening it everytime need arises.
     """
 
-    def __set__(self, obj, val: rasterio.DatasetReader):
+    def __set__(self, obj, val: Optional[rasterio.DatasetReader]):
+        source = obj.__dict__.get('source')
+        if source is not None:
+            source.close()
         obj.__dict__['source'] = val
 
     def __get__(self, obj, objtype=None) -> rasterio.DatasetReader:
@@ -345,6 +357,9 @@ class Raster:
         self._path = path
         self._crs = crs
 
+    def __del__(self):
+        self._tmpfile = None
+
     def __iter__(self, chunk_size: int = None, overlap: int = None):
         for window in self.iter_windows(chunk_size, overlap):
             yield window, self.get_window_bounds(window)
@@ -382,14 +397,15 @@ class Raster:
         no_except = False
         try:
             # pylint: disable=R1732
-            tmpfile = tempfile.NamedTemporaryFile(prefix=tmpdir)
+#            tmpfile = tempfile.NamedTemporaryFile(prefix=tmpdir, mode='w')
+            tmpfd, tmppath = tempfile.mkstemp(prefix=tmpdir)
 
             new_meta = kwargs
             # Flag to workaround cases where "src" is NOT set yet
             if use_src_meta:
                 new_meta = self.src.meta.copy()
                 new_meta.update(**kwargs)
-            with rasterio.open(tmpfile.name, 'w', **new_meta) as dst:
+            with rasterio.open(tmppath, 'w', **new_meta) as dst:
                 if use_src_meta:
                     for i, desc in enumerate(self.src.descriptions):
                         dst.set_band_description(i+1, desc)
@@ -399,9 +415,12 @@ class Raster:
 
         finally:
             if no_except:
-                # So that tmpfile is NOT destroyed when it locally
-                # goes out of scope
-                self._tmpfile = tmpfile
+                self._tmpfile = tmppath
+
+            # We don't need to keep the descriptor open, we kept it
+            # open # so that there's no race condition on the temp
+            # file up to now
+            os.close(tmpfd)
 
 
 
@@ -944,6 +963,8 @@ class Raster:
         # in other parts of the code. Thorough testing is needed for
         # modifying the raster (e.g. hfun add_contour is affected)
 
+        if platform.system() == 'Windows':
+            raise ImplementationError('Not supported on Windows!')
         bands = apply_on_bands
         if bands is None:
             bands = range(1, self.src.count + 1)
@@ -1001,6 +1022,9 @@ class Raster:
         -------
         None
         """
+
+        if platform.system() == 'Windows':
+            raise ImplementationError('Not supported on Windows!')
 
         # TODO: Don't overwrite; add additoinal bands for filtered values
 

--- a/ocsmesh/raster.py
+++ b/ocsmesh/raster.py
@@ -395,6 +395,7 @@ class Raster:
         """
 
         no_except = False
+        tmpfd = None
         try:
             # pylint: disable=R1732
 #            tmpfile = tempfile.NamedTemporaryFile(prefix=tmpdir, mode='w')
@@ -420,7 +421,8 @@ class Raster:
             # We don't need to keep the descriptor open, we kept it
             # open # so that there's no race condition on the temp
             # file up to now
-            os.close(tmpfd)
+            if tmpfd is not None:
+                os.close(tmpfd)
 
 
 
@@ -964,7 +966,7 @@ class Raster:
         # modifying the raster (e.g. hfun add_contour is affected)
 
         if platform.system() == 'Windows':
-            raise ImplementationError('Not supported on Windows!')
+            raise NotImplementedError('Not supported on Windows!')
         bands = apply_on_bands
         if bands is None:
             bands = range(1, self.src.count + 1)
@@ -1024,7 +1026,7 @@ class Raster:
         """
 
         if platform.system() == 'Windows':
-            raise ImplementationError('Not supported on Windows!')
+            raise NotImplementedError('Not supported on Windows!')
 
         # TODO: Don't overwrite; add additoinal bands for filtered values
 

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -14,9 +14,10 @@ tif_url = (
 )
 TEST_FILE = os.path.join(tempfile.gettempdir(), 'test_dem.tif')
 if not Path(TEST_FILE).exists():
-    with tempfile.NamedTemporaryFile() as tfp:
-        urllib.request.urlretrieve(tif_url, filename=tfp.name)
-        r = Raster(tfp.name)
-        r.resampling_method = Resampling.average
-        r.resample(scaling_factor=0.01)
-        r.save(TEST_FILE)
+    tmpfd, tmppath = tempfile.mkstemp()
+    urllib.request.urlretrieve(tif_url, filename=tmppath)
+    os.close(tmpfd)
+    r = Raster(tmppath)
+    r.resampling_method = Resampling.average
+    r.resample(scaling_factor=0.01)
+    r.save(TEST_FILE)

--- a/tests/api/__init__.py
+++ b/tests/api/__init__.py
@@ -1,7 +1,22 @@
 import os
-os.system("""
-    ls /tmp/test_dem.tif > /dev/null
-    if [ $? -eq 0 ]; then exit; fi
-    wget https://coast.noaa.gov/htdata/raster2/elevation/NCEI_ninth_Topobathy_2014_8483/northeast_sandy/ncei19_n40x75_w073x75_2015v1.tif -O /tmp/fullsize_dem.tif
-    gdalwarp -tr 0.0005 0.0005 -r average -overwrite /tmp/fullsize_dem.tif /tmp/test_dem.tif
-""")
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from rasterio.enums import Resampling
+
+from ocsmesh.raster import Raster
+
+
+# Find a better way!
+tif_url = (
+    'https://coast.noaa.gov/htdata/raster2/elevation/NCEI_ninth_Topobathy_2014_8483/northeast_sandy/ncei19_n40x75_w073x75_2015v1.tif'
+)
+TEST_FILE = os.path.join(tempfile.gettempdir(), 'test_dem.tif')
+if not Path(TEST_FILE).exists():
+    with tempfile.NamedTemporaryFile() as tfp:
+        urllib.request.urlretrieve(tif_url, filename=tfp.name)
+        r = Raster(tfp.name)
+        r.resampling_method = Resampling.average
+        r.resample(scaling_factor=0.01)
+        r.save(TEST_FILE)

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -13,6 +13,7 @@ from shapely import geometry
 
 import ocsmesh
 
+from tests.api import TEST_FILE
 from tests.api.common import (
     topo_2rast_1mesh,
 )
@@ -492,7 +493,7 @@ class SizeFunctionCollector(unittest.TestCase):
 class SizeFromMesh(unittest.TestCase):
 
     def setUp(self):
-        rast = ocsmesh.raster.Raster('/tmp/test_dem.tif')
+        rast = ocsmesh.raster.Raster(TEST_FILE)
 
         hfun_orig = ocsmesh.hfun.hfun.Hfun(rast, hmin=100, hmax=1500)
         hfun_orig.add_contour(level=0, expansion_rate=0.001, target_size=100)
@@ -530,7 +531,7 @@ class SizeFunctionWithCourantNumConstraint(unittest.TestCase):
         courant_hi = 0.8
         courant_lo = 0.2
 
-        rast = ocsmesh.raster.Raster('/tmp/test_dem.tif')
+        rast = ocsmesh.raster.Raster(TEST_FILE)
 
         hfun_raster = ocsmesh.hfun.hfun.Hfun(rast, hmin=100, hmax=5000)
         hfun_raster.add_courant_num_constraint(
@@ -586,7 +587,7 @@ class SizeFunctionWithCourantNumConstraint(unittest.TestCase):
         )
 
     def test_hfun_raster_cfl_constraint_io(self):
-        rast = ocsmesh.raster.Raster('/tmp/test_dem.tif')
+        rast = ocsmesh.raster.Raster(TEST_FILE)
         hfun_raster = ocsmesh.hfun.hfun.Hfun(rast, hmin=100, hmax=5000)
         self.assertRaises(
             ValueError,
@@ -614,8 +615,8 @@ class SizeFunctionWithCourantNumConstraint(unittest.TestCase):
             # TODO: Add subTest
 
             # Creating adjacent rasters from the test raster
-            rast1 = ocsmesh.raster.Raster('/tmp/test_dem.tif')
-            rast2 = ocsmesh.raster.Raster('/tmp/test_dem.tif')
+            rast1 = ocsmesh.raster.Raster(TEST_FILE)
+            rast2 = ocsmesh.raster.Raster(TEST_FILE)
             bounds = rast1.bbox.bounds
             bbox1 = geometry.box(
                 bounds[0], bounds[1], (bounds[0] + bounds[2]) / 2, bounds[3]

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -513,8 +513,8 @@ class SizeFromMesh(unittest.TestCase):
         hfun_val_diff = self.hfun_orig_val - hfun_calc_val
 
         # TODO: Come up with a more robust criteria!
-        threshold = 0.21
-        err_value = np.max(np.abs(hfun_val_diff))/np.max(self.hfun_orig_val)
+        threshold = 0.05
+        err_value = np.mean(np.abs(hfun_val_diff))/np.mean(self.hfun_orig_val)
         self.assertTrue(err_value < threshold)
 
 

--- a/tests/api/hfun.py
+++ b/tests/api/hfun.py
@@ -907,7 +907,6 @@ class SizeFunctionWithRegionConstraint(unittest.TestCase):
             )
             mesh = ocsmesh.Mesh(msh_t)
             mesh.write(str(self.mesh1), format='grd', overwrite=False)
-            mesh.write('/tmp/ocsmesh/mytest2.2dm', format='2dm', overwrite=True)
 
 
     def tearDown(self):

--- a/tests/api/mesh.py
+++ b/tests/api/mesh.py
@@ -1,4 +1,5 @@
 #! python
+import os
 import tempfile
 import unittest
 import warnings
@@ -279,9 +280,11 @@ class BoundaryExtraction(unittest.TestCase):
     def test_specify_boundary_on_imported_mesh_with_boundary(self):
         self.mesh.boundaries.auto_generate()
 
-        with tempfile.NamedTemporaryFile(suffix='.grd') as fo:
-            self.mesh.write(fo.name, format='grd', overwrite=True)
-            imported_mesh = Mesh.open(fo.name)
+        tmpfd, tmppath = tempfile.mkstemp(suffix='.grd')
+        self.mesh.write(tmppath, format='grd', overwrite=True)
+        imported_mesh = Mesh.open(tmppath)
+        os.close(tmpfd)
+        os.unlink(tmppath)
 
         bdry = imported_mesh.boundaries
 

--- a/tests/api/raster.py
+++ b/tests/api/raster.py
@@ -1,12 +1,17 @@
 import shutil
 import tempfile
 import unittest
+import platform
 from pathlib import Path
 
 import numpy as np
 
 import ocsmesh
 from ocsmesh.utils import raster_from_numpy
+
+
+IS_WINDOWS = platform.system() == 'Windows'
+
 
 
 class Raster(unittest.TestCase):
@@ -38,21 +43,33 @@ class Raster(unittest.TestCase):
         shutil.rmtree(self.tdir)
 
 
+    @unittest.skipIf(IS_WINDOWS, 'Not supported due to LowLevelFunction int')
     def test_avg_filter_nomask(self):
-        rast = ocsmesh.Raster(self.rast1)
-        rast.average_filter(size=17)
-        self.assertTrue(np.all(rast.get_values() == 10))
+        try:
+            rast = ocsmesh.Raster(self.rast1)
+            rast.average_filter(size=17)
+            self.assertTrue(np.all(rast.get_values() == 10))
+        finally:
+            del rast
 
 
+    @unittest.skipIf(IS_WINDOWS, 'Not supported due to LowLevelFunction int')
     def test_avg_filter_masked_nanfill(self):
-        rast = ocsmesh.Raster(self.rast2)
-        rast.average_filter(size=17)
-        self.assertTrue(
-            np.all(rast.values[~np.isnan(rast.values)] == 10))
+        try:
+            rast = ocsmesh.Raster(self.rast2)
+            rast.average_filter(size=17)
+            self.assertTrue(
+                np.all(rast.values[~np.isnan(rast.values)] == 10))
+        finally:
+            del rast
 
 
+    @unittest.skipIf(IS_WINDOWS, 'Not supported due to LowLevelFunction int')
     def test_avg_filter_masked_nonnanfill(self):
-        rast = ocsmesh.Raster(self.rast3)
-        rast.average_filter(size=17)
-        self.assertTrue(
-            np.all(rast.values[rast.values != rast.nodata] == 10))
+        try:
+            rast = ocsmesh.Raster(self.rast3)
+            rast.average_filter(size=17)
+            self.assertTrue(
+                np.all(rast.values[rast.values != rast.nodata] == 10))
+        finally:
+            del rast


### PR DESCRIPTION
- Modify how `tempfile` is used for rasters or within tests
    - Use `mkstemp` instead of `NamedTemporaryFile`
    - Add explicit cleanup steps
- Enable automated tests for API on Windows (mamba env)