### PR TITLE
added cleanup_folded_bound_el

### DIFF
--- a/ocsmesh/geom/collector.py
+++ b/ocsmesh/geom/collector.py
@@ -248,7 +248,7 @@ class GeomCollector(BaseGeom):
                 else:
                     raise TypeError("Input file extension not supported!")
 
-            self._geom_list.append(geom)
+            self._geom_list.append(geom) # pylint: disable=E0606
 
 
     def get_multipolygon(self, **kwargs: Any) -> MultiPolygon:

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -786,7 +786,7 @@ class HfunCollector(BaseHfun):
                 else:
                     raise TypeError("Input file extension not supported!")
 
-            self._hfun_list.append(hfun)
+            self._hfun_list.append(hfun) # pylint: disable=E0606
 
 
     def msh_t(self) -> jigsaw_msh_t:

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -22,7 +22,7 @@ from shapely.geometry import (
 )
 from shapely.ops import polygonize
 
-from ocsmesh import Raster, utils, Mesh
+from ocsmesh import Raster, utils
 
 
 class SetUp(unittest.TestCase):
@@ -127,9 +127,8 @@ class FinalizeMesh(unittest.TestCase):
         folded_bound_el_mesh = Mesh.open(p, crs=4326)
 
         cleaned_mesh = utils.cleanup_folded_bound_el(folded_bound_el_mesh)
-        cleaned_mesh = Mesh(cleaned_mesh)
 
-        self.assertEqual(len(cleaned_mesh.elements()), 1130295)
+        self.assertEqual(len(cleaned_mesh.tria3), 1130295)
 
 
 class RemovePolygonHoles(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -129,7 +129,7 @@ class FinalizeMesh(unittest.TestCase):
         cleaned_mesh = utils.cleanup_folded_bound_el(folded_bound_el_mesh)
         cleaned_mesh = Mesh(cleaned_mesh)
 
-        self.assertEqual(len(cleaned_mesh.elements()), 1130302)
+        self.assertEqual(len(cleaned_mesh.elements()), 1130295)
 
 
 class RemovePolygonHoles(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -123,7 +123,7 @@ class FinalizeMesh(unittest.TestCase):
     def test_cleanup_folded_bound_el(self):
 
         # Open mesh that has folded boundary elements
-        p = Path().absolute().parents[0] / "data" / "before_cleanup_folded_bound_el.2dm"
+        p = Path(__file__).parents[0] / "data" / "before_cleanup_folded_bound_el.2dm"
         folded_bound_el_mesh = Mesh.open(p, crs=4326)
         
         utils.cleanup_folded_bound_el(folded_bound_el_mesh)

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -123,7 +123,7 @@ class FinalizeMesh(unittest.TestCase):
     def test_cleanup_folded_bound_el(self):
 
         # Open mesh that has folded boundary elements
-        p = Path(__file__).parents[0] / "data" / "before_cleanup_folded_bound_el.2dm"
+        p = Path(__file__).parents[1] / "data" / "before_cleanup_folded_bound_el.2dm"
         folded_bound_el_mesh = Mesh.open(p, crs=4326)
         
         utils.cleanup_folded_bound_el(folded_bound_el_mesh)

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -125,8 +125,11 @@ class FinalizeMesh(unittest.TestCase):
         # Open mesh that has folded boundary elements
         p = Path(__file__).parents[1] / "data" / "before_cleanup_folded_bound_el.2dm"
         folded_bound_el_mesh = Mesh.open(p, crs=4326)
-        
-        utils.cleanup_folded_bound_el(folded_bound_el_mesh)
+
+        cleaned_mesh = utils.cleanup_folded_bound_el(folded_bound_el_mesh)
+        cleaned_mesh = Mesh(cleaned_mesh)
+
+        self.assertEqual(len(cleaned_mesh.elements()), 1130302)
 
 
 class RemovePolygonHoles(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -22,7 +22,7 @@ from shapely.geometry import (
 )
 from shapely.ops import polygonize
 
-from ocsmesh import Raster, utils
+from ocsmesh import Raster, utils, Mesh
 
 
 class SetUp(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -22,7 +22,7 @@ from shapely.geometry import (
 )
 from shapely.ops import polygonize
 
-from ocsmesh import Raster, utils
+from ocsmesh import Raster, utils, Mesh
 
 
 class SetUp(unittest.TestCase):
@@ -119,6 +119,14 @@ class FinalizeMesh(unittest.TestCase):
             utils.get_boundary_segments(mesh_comb)
         except ValueError as e:
             self.fail(str(e))
+
+    def test_cleanup_folded_bound_el(self):
+
+        # Open mesh that has folded boundary elements
+        p = Path().absolute().parents[0] / "data" / "before_cleanup_folded_bound_el.2dm"
+        folded_bound_el_mesh = Mesh.open(p, crs=4326)
+        
+        utils.cleanup_folded_bound_el(folded_bound_el_mesh)
 
 
 class RemovePolygonHoles(unittest.TestCase):


### PR DESCRIPTION
added and tested the function cleanup_folded_bound_el under utils.
This function deletes all boundary elements whose nodes (all 3) are boundary nodes.

Checked pylint score, was 8.29, now is 8.31.