### PR TITLE
Tri to quads 02

### DIFF
--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -74,6 +74,10 @@ jobs:
         path: /tmp/test_dem.tif
         retention-days: 7
 
+    - name: Run Python API tests
+      shell: bash -el {0}
+      run: python -m unittest discover tests/api -p "utils.py"
+
     - name: Run geom build test
       if: runner.os != 'Windows'
       shell: bash -l {0}
@@ -113,6 +117,6 @@ jobs:
         path: remeshed.2dm
         retention-days: 7
 
-    - name: Run Python API tests
-      shell: bash -el {0}
-      run: python -m unittest discover tests/api -p "*.py"
+    # - name: Run Python API tests
+    #   shell: bash -el {0}
+    #   run: python -m unittest discover tests/api -p "*.py"

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -74,10 +74,6 @@ jobs:
         path: /tmp/test_dem.tif
         retention-days: 7
 
-    - name: Run Python API tests
-      shell: bash -el {0}
-      run: python -m unittest discover tests/api -p "utils.py"
-
     - name: Run geom build test
       if: runner.os != 'Windows'
       shell: bash -l {0}
@@ -117,6 +113,6 @@ jobs:
         path: remeshed.2dm
         retention-days: 7
 
-    # - name: Run Python API tests
-    #   shell: bash -el {0}
-    #   run: python -m unittest discover tests/api -p "*.py"
+    - name: Run Python API tests
+      shell: bash -el {0}
+      run: python -m unittest discover tests/api -p "*.py"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -36,5 +36,6 @@ jobs:
         python ./setup.py install_jigsaw
         pip install .[testing]
     - name: Analysing the code with pylint
+      run: |
       shell: bash -l {0}
       run: pylint ocsmesh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Analysing the code with pylint
       shell: bash -l {0}
       run: |
-      run: pylint ocsmesh
+        pylint ocsmesh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,20 +24,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Mamba environment for Python
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: ./environment.yml
-          environment-name: ocsmesh-env
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          python ./setup.py install_jigsaw
-          pip install .[testing]
-      - name: Analysing the code with pylint
-        shell: bash -l {0}
-        run: |
-          pylint $(git ls-files '*.py') --output=lint.txt || true
-        # run: |
-        #   run: pylint ocsmesh
+    - uses: actions/checkout@v3
+    - name: Setup Mamba environment for Python
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: ./environment.yml
+        environment-name: ocsmesh-env
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        python ./setup.py install_jigsaw
+        pip install .[testing]
+    - name: Analysing the code with pylint
+      shell: bash -l {0}
+      run: pylint ocsmesh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -37,4 +37,5 @@ jobs:
         pip install .[testing]
     - name: Analysing the code with pylint
       shell: bash -l {0}
-      run: pylint ocsmesh
+      run: |
+        pylint ocsmesh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,18 +24,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup Mamba environment for Python
-      uses: mamba-org/provision-with-micromamba@main
-      with:
-        environment-file: ./environment.yml
-        environment-name: ocsmesh-env
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: |
-        python ./setup.py install_jigsaw
-        pip install .[testing]
-    - name: Analysing the code with pylint
-      shell: bash -l {0}
-      run: |
-        pylint ocsmesh
+      - uses: actions/checkout@v3
+      - name: Setup Mamba environment for Python
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ./environment.yml
+          environment-name: ocsmesh-env
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          python ./setup.py install_jigsaw
+          pip install .[testing]
+      - name: Analysing the code with pylint
+        shell: bash -l {0}
+        run: |
+          pylint $(git ls-files '*.py') --output=lint.txt || true
+        # run: |
+        #   run: pylint ocsmesh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -36,6 +36,6 @@ jobs:
         python ./setup.py install_jigsaw
         pip install .[testing]
     - name: Analysing the code with pylint
-      run: |
       shell: bash -l {0}
+      run: |
       run: pylint ocsmesh

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - shapely
   - rasterio
   - fiona
-  - geopandas
+  - geopandas<=0.14.4
   - utm
   - scipy
   - numba

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2685,7 +2685,7 @@ def create_mesh_from_mesh_diff(domain: Union[jigsaw_msh_t,
                                mesh_2: jigsaw_msh_t,
                                crs=CRS.from_epsg(4326),
                                min_int_ang=None,
-                               buffer_domain = 0.001                            
+                               buffer_domain = 0.001
 ) -> jigsaw_msh_t:
     '''
     Create a triangulation for the area correspondent to
@@ -3009,7 +3009,7 @@ def merge_overlapping_meshes(all_msht: list,
 #     -------
 #     np.array
 #         internal angles of each element
-    
+
 #     Notes
 
 #     -----
@@ -3076,8 +3076,8 @@ def merge_overlapping_meshes(all_msht: list,
 #     jigsawpy.msh_t.jigsaw_msh_t
 #     -------
 #     np.array
-#         mesh whose nodes within each element are oriented counterclockwise 
-    
+#         mesh whose nodes within each element are oriented counterclockwise
+
 #     Notes
 #     -----
 #     '''
@@ -3154,7 +3154,7 @@ def merge_overlapping_meshes(all_msht: list,
 #     -------
 #     jigsawpy.msh_t.jigsaw_msh_t
 #         quadrangular + triangular mesh
-    
+
 #     Notes
 #     -----
 #     """
@@ -3185,7 +3185,7 @@ def merge_overlapping_meshes(all_msht: list,
 #     # separte the triangles to then be merged back to the quads
 #     tris_drop=[]
 #     for idxs in result.values():
-#         tris_drop.append(idxs) 
+#         tris_drop.append(idxs)
 #     tris_drop = np.array(tris_drop).ravel()
 #     tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
 
@@ -3195,7 +3195,7 @@ def merge_overlapping_meshes(all_msht: list,
 #     quads=[]
 #     for idxs in result.values():
 #         quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
-    
+
 #     quads = np.array(quads)
 #     coords = msht.vert2['coord']
 

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2995,222 +2995,221 @@ def merge_overlapping_meshes(all_msht: list,
     return msht_combined
 
 
+# def calc_el_angles(msht):
+#     '''
+#     Adapted from: https://github.com/SorooshMani-NOAA/river-in-mesh/tree/main/river_in_mesh
 
-def calc_el_angles(msht):
-    '''
-    Adapted from: https://github.com/SorooshMani-NOAA/river-in-mesh/tree/main/river_in_mesh
+#     Calculates the internal angle of each node for element (triangular or quadrangular)
 
-    Calculates the internal angle of each node for element (triangular or quadrangular)
+#     Parameters
+#     ----------
+#     msht : jigsawpy.msh_t.jigsaw_msh_t
 
-    Parameters
-    ----------
-    msht : jigsawpy.msh_t.jigsaw_msh_t
-
-    Returns
-    -------
-    np.array
-        internal angles of each element
+#     Returns
+#     -------
+#     np.array
+#         internal angles of each element
     
-    Notes
+#     Notes
 
-    -----
-    '''
+#     -----
+#     '''
 
-    tri,quad=[],[]
-    for etype in ELEM_2D_TYPES[:-1]:
-        el = getattr(msht, etype)['index']
-        coord_verts = msht.vert2['coord'][el]
+#     tri,quad=[],[]
+#     for etype in ELEM_2D_TYPES[:-1]:
+#         el = getattr(msht, etype)['index']
+#         coord_verts = msht.vert2['coord'][el]
 
-        tria_verts = coord_verts[:,:3]
-        sides = np.linalg.norm(
-            tria_verts - np.roll(tria_verts, shift=-1, axis=1),
-            axis=2
-        )
+#         tria_verts = coord_verts[:,:3]
+#         sides = np.linalg.norm(
+#             tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+#             axis=2
+#         )
 
-        ang_0_0 = np.degrees(np.arccos(
-            (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
-                / (2 * sides[:, 1] * sides[:, 2])
-        ))
-        ang_1_0 = np.degrees(np.arccos(
-            (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
-                / (2 * sides[:, 0] * sides[:, 2])
-        ))
-        ang_2_0 = 180 - (ang_0_0 + ang_1_0)
+#         ang_0_0 = np.degrees(np.arccos(
+#             (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+#                 / (2 * sides[:, 1] * sides[:, 2])
+#         ))
+#         ang_1_0 = np.degrees(np.arccos(
+#             (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+#                 / (2 * sides[:, 0] * sides[:, 2])
+#         ))
+#         ang_2_0 = 180 - (ang_0_0 + ang_1_0)
 
-        if etype == 'tria3' and len(el) > 0:
-            tri.append(np.vstack((ang_1_0, ang_2_0, ang_0_0)).T)
-        if etype == 'quad4' and len(el) > 0:
-            tria_verts = coord_verts[:,[2,3,0]]
-            sides = np.linalg.norm(
-                tria_verts - np.roll(tria_verts, shift=-1, axis=1),
-                axis=2
-            )
+#         if etype == 'tria3' and len(el) > 0:
+#             tri.append(np.vstack((ang_1_0, ang_2_0, ang_0_0)).T)
+#         if etype == 'quad4' and len(el) > 0:
+#             tria_verts = coord_verts[:,[2,3,0]]
+#             sides = np.linalg.norm(
+#                 tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+#                 axis=2
+#             )
 
-            ang_0_1 = np.degrees(np.arccos(
-                (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
-                    / (2 * sides[:, 1] * sides[:, 2])
-            ))
-            ang_1_1 = np.degrees(np.arccos(
-                (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
-                    / (2 * sides[:, 0] * sides[:, 2])
-            ))
-            ang_2_1 = 180 - (ang_0_1 + ang_1_1)
+#             ang_0_1 = np.degrees(np.arccos(
+#                 (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+#                     / (2 * sides[:, 1] * sides[:, 2])
+#             ))
+#             ang_1_1 = np.degrees(np.arccos(
+#                 (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+#                     / (2 * sides[:, 0] * sides[:, 2])
+#             ))
+#             ang_2_1 = 180 - (ang_0_1 + ang_1_1)
 
-            quad.append(np.vstack(((ang_1_0+ang_0_1), ang_2_0,
-                                   (ang_0_0+ang_1_1), ang_2_1)).T)
+#             quad.append(np.vstack(((ang_1_0+ang_0_1), ang_2_0,
+#                                    (ang_0_0+ang_1_1), ang_2_1)).T)
 
-    return np.array(tri),np.array(quad)
+#     return np.array(tri),np.array(quad)
 
 
-def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
-    '''
-    Order mesh nodes counterclockwise (triangles and quads)
-    based on the coordinates
+# def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
+#     '''
+#     Order mesh nodes counterclockwise (triangles and quads)
+#     based on the coordinates
 
-    Parameters
-    ----------
-    msht : jigsawpy.msh_t.jigsaw_msh_t
-        mesh with nodes out of order
+#     Parameters
+#     ----------
+#     msht : jigsawpy.msh_t.jigsaw_msh_t
+#         mesh with nodes out of order
 
-    Returns
-    -------
-    jigsawpy.msh_t.jigsaw_msh_t
-    -------
-    np.array
-        mesh whose nodes within each element are oriented counterclockwise 
+#     Returns
+#     -------
+#     jigsawpy.msh_t.jigsaw_msh_t
+#     -------
+#     np.array
+#         mesh whose nodes within each element are oriented counterclockwise 
     
-    Notes
-    -----
-    '''
+#     Notes
+#     -----
+#     '''
 
-    def order_nodes(verts):
-        '''
-        Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
-        '''
+#     def order_nodes(verts):
+#         '''
+#         Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
+#         '''
 
-        xSorted_idx = np.argsort(verts[:, 0])
-        xSorted = verts[xSorted_idx, :]
+#         xSorted_idx = np.argsort(verts[:, 0])
+#         xSorted = verts[xSorted_idx, :]
 
-        leftMost = xSorted[:2, :]
-        leftMost_idx = xSorted_idx[:2]
-        rightMost = xSorted[2:, :]
-        rightMost_idx = xSorted_idx[2:]
+#         leftMost = xSorted[:2, :]
+#         leftMost_idx = xSorted_idx[:2]
+#         rightMost = xSorted[2:, :]
+#         rightMost_idx = xSorted_idx[2:]
 
-        leftMost_idx = leftMost_idx[np.argsort(leftMost[:, 1])]
-        (tl_idx, bl_idx) = leftMost_idx
+#         leftMost_idx = leftMost_idx[np.argsort(leftMost[:, 1])]
+#         (tl_idx, bl_idx) = leftMost_idx
 
-        rightMost_idx = rightMost_idx[np.argsort(rightMost[:, 1])]
+#         rightMost_idx = rightMost_idx[np.argsort(rightMost[:, 1])]
 
-        if len(verts) == 4:
-            (tr_idx, br_idx) = rightMost_idx
-            return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
-        if len(verts) == 3:
-            return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
+#         if len(verts) == 4:
+#             (tr_idx, br_idx) = rightMost_idx
+#             return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
+#         if len(verts) == 3:
+#             return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
 
-    #order all element's nodes counterclockwise
-    tri,quad=[],[]
-    coord_verts = msht.vert2['coord']
-    for etype in ELEM_2D_TYPES[:-1]:
-        el = getattr(msht, etype)['index']
-        if len(el) > 0:
-            ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
-            ordered_el = np.zeros(el.shape,dtype="int")
-            for i in range(len(ordered_el)):
-                ordered_el[i] = el[i][ordered_idx[i]]
-            if etype == 'tria3':
-                tri.append(ordered_el)
-            if etype == 'quad4':
-                quad.append(ordered_el)
-    if len(tri)>0 and len(quad)>0:
-        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-                                       triangles = tri[0],
-                                       quadrilaterals = quad[0],
-                                       crs = crs)
-    elif len(tri)>0 and len(quad)==0:
-        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-                                       triangles = tri[0],
-                                       crs = crs)
-    if len(tri)==0 and len(quad)>0:
-        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-                                       quadrilaterals = quad[0],
-                                       crs = crs)
+#     #order all element's nodes counterclockwise
+#     tri,quad=[],[]
+#     coord_verts = msht.vert2['coord']
+#     for etype in ELEM_2D_TYPES[:-1]:
+#         el = getattr(msht, etype)['index']
+#         if len(el) > 0:
+#             ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
+#             ordered_el = np.zeros(el.shape,dtype="int")
+#             for i in range(len(ordered_el)):
+#                 ordered_el[i] = el[i][ordered_idx[i]]
+#             if etype == 'tria3':
+#                 tri.append(ordered_el)
+#             if etype == 'quad4':
+#                 quad.append(ordered_el)
+#     if len(tri)>0 and len(quad)>0:
+#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+#                                        triangles = tri[0],
+#                                        quadrilaterals = quad[0],
+#                                        crs = crs)
+#     elif len(tri)>0 and len(quad)==0:
+#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+#                                        triangles = tri[0],
+#                                        crs = crs)
+#     if len(tri)==0 and len(quad)>0:
+#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+#                                        quadrilaterals = quad[0],
+#                                        crs = crs)
 
-    return mesh_ordered
+#     return mesh_ordered
 
 
-def quads_from_tri(msht) -> jigsaw_msh_t:
-    """
-    Partially adapted from:
-    https://stackoverflow.com/questions/69605766/find-position-of-duplicate-elements-in-list
+# def quads_from_tri(msht) -> jigsaw_msh_t:
+#     """
+#     Partially adapted from:
+#     https://stackoverflow.com/questions/69605766/find-position-of-duplicate-elements-in-list
 
-    Combines all triangles that share vertices that are not right angles.
-    right angles is defined as the internal angle closest to 90deg
+#     Combines all triangles that share vertices that are not right angles.
+#     right angles is defined as the internal angle closest to 90deg
 
-    Parameters
-    ----------
-    msht : jigsawpy.msh_t.jigsaw_msh_t
-        triangular mesh
+#     Parameters
+#     ----------
+#     msht : jigsawpy.msh_t.jigsaw_msh_t
+#         triangular mesh
 
-    Returns
-    -------
-    jigsawpy.msh_t.jigsaw_msh_t
-        quadrangular + triangular mesh
+#     Returns
+#     -------
+#     jigsawpy.msh_t.jigsaw_msh_t
+#         quadrangular + triangular mesh
     
-    Notes
-    -----
-    """
+#     Notes
+#     -----
+#     """
 
-    ang_chk = calc_el_angles(msht)[0][0]
-    el = msht.tria3['index']
+#     ang_chk = calc_el_angles(msht)[0][0]
+#     el = msht.tria3['index']
 
-    try:
-        el_q = msht.quad4['index']
-    except:
-        el_q = []
+#     try:
+#         el_q = msht.quad4['index']
+#     except:
+#         el_q = []
 
-    # Finds the idx of the vertices closes to 90 deg
-    # Then, creates an array of non right angle vertices (shared)
-    idx_of_closest = np.abs(ang_chk - 90).argmin(axis=1)
-    # right = np.array([el[row,column] for row,column in enumerate(idx_of_closest)])
-    shared = np.array([np.delete(el[row],column) for \
-                       row,column in enumerate(idx_of_closest)])
-    shared.sort()
+#     # Finds the idx of the vertices closes to 90 deg
+#     # Then, creates an array of non right angle vertices (shared)
+#     idx_of_closest = np.abs(ang_chk - 90).argmin(axis=1)
+#     # right = np.array([el[row,column] for row,column in enumerate(idx_of_closest)])
+#     shared = np.array([np.delete(el[row],column) for \
+#                        row,column in enumerate(idx_of_closest)])
+#     shared.sort()
 
-    #Creates a dict of all elements that share 2 non-right angle vertices
-    duplicates = defaultdict(list)
-    for i, number in enumerate(shared):
-        duplicates[str(number)].append(i)
+#     #Creates a dict of all elements that share 2 non-right angle vertices
+#     duplicates = defaultdict(list)
+#     for i, number in enumerate(shared):
+#         duplicates[str(number)].append(i)
 
-    result = {key: value for key, value in duplicates.items() if len(value) > 1}
+#     result = {key: value for key, value in duplicates.items() if len(value) > 1}
 
-    # separte the triangles to then be merged back to the quads
-    tris_drop=[]
-    for idxs in result.values():
-        tris_drop.append(idxs) 
-    tris_drop = np.array(tris_drop).ravel()
-    tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
+#     # separte the triangles to then be merged back to the quads
+#     tris_drop=[]
+#     for idxs in result.values():
+#         tris_drop.append(idxs) 
+#     tris_drop = np.array(tris_drop).ravel()
+#     tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
 
-    # combines all triangles that share 2 non-right angle vertices
-    # the quads array is composed of 2 right angle nodes (idx_of_closest)
-    # and 2 shared nodes (result)
-    quads=[]
-    for idxs in result.values():
-        quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
+#     # combines all triangles that share 2 non-right angle vertices
+#     # the quads array is composed of 2 right angle nodes (idx_of_closest)
+#     # and 2 shared nodes (result)
+#     quads=[]
+#     for idxs in result.values():
+#         quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
     
-    quads = np.array(quads)
-    coords = msht.vert2['coord']
+#     quads = np.array(quads)
+#     coords = msht.vert2['coord']
 
-    msht_q = msht_from_numpy(coordinates = coords,
-                             triangles = tris,
-                             quadrilaterals = quads)
+#     msht_q = msht_from_numpy(coordinates = coords,
+#                              triangles = tris,
+#                              quadrilaterals = quads)
 
-    if len(el_q) > 0:
-        msht_previous_quads = msht_from_numpy(coordinates = coords,
-                                              quadrilaterals = el_q)
-        msht_q = merge_neighboring_meshes(msht_previous_quads,msht_q)
+#     if len(el_q) > 0:
+#         msht_previous_quads = msht_from_numpy(coordinates = coords,
+#                                               quadrilaterals = el_q)
+#         msht_q = merge_neighboring_meshes(msht_previous_quads,msht_q)
 
-    msht_q = order_mesh(msht_q)
-    cleanup_duplicates(msht_q)
-    put_id_tags(msht_q)
+#     msht_q = order_mesh(msht_q)
+#     cleanup_duplicates(msht_q)
+#     put_id_tags(msht_q)
 
-    return msht_q
+#     return msht_q

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3087,7 +3087,7 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
         '''
         Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
         '''
-
+        order=[]
         xSorted_idx = np.argsort(verts[:, 0])
         xSorted = verts[xSorted_idx, :]
 

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3184,11 +3184,11 @@ def quads_from_tri(msht) -> jigsaw_msh_t:
 
     result = {key: value for key, value in duplicates.items() if len(value) > 1}
 
-    # separte the triangles to then be merged back to the quads
+    # separate the triangles to then be merged back to the quads
     tris_drop=[]
     for idxs in result.values():
         tris_drop.append(idxs)
-    tris_drop = np.array(tris_drop).ravel()
+    tris_drop = np.array(tris_drop, dtype="int").ravel()
     tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
 
     # combines all triangles that share 2 non-right angle vertices

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2658,7 +2658,7 @@ def clip_mesh_by_mesh(mesh_to_be_clipped: jigsaw_msh_t,
     gdf_clipper = [get_mesh_polygons(mesh_clipper)]
     gdf_clipper = gpd.GeoDataFrame(geometry=gdf_clipper, crs=crs)
 
-    if buffer_size != None:
+    if buffer_size is not None:
         gdf_clipper.crs = gdf_clipper.estimate_utm_crs()
         gdf_clipper.geometry = gdf_clipper.buffer(buffer_size)
         gdf_clipper.crs = crs
@@ -2715,7 +2715,7 @@ def create_mesh_from_mesh_diff(domain: Union[jigsaw_msh_t,
     '''
 
     if isinstance(domain, (gpd.GeoDataFrame)):
-        domain = domain
+        pass
     if isinstance(domain, (gpd.GeoSeries)):
         domain = gpd.GeoDataFrame(geometry=gpd.GeoSeries(domain))
     if isinstance(domain, Polygon):
@@ -2750,7 +2750,7 @@ def create_mesh_from_mesh_diff(domain: Union[jigsaw_msh_t,
     gdf_full_buffer = gpd.GeoDataFrame(
         geometry = [poly_buffer],crs=crs)
 
-    if min_int_ang == None:
+    if min_int_ang is None:
         msht_buffer = triangulate_polygon(gdf_full_buffer)
     else:
         msht_buffer = triangulate_polygon_s(gdf_full_buffer,min_int_ang=min_int_ang)
@@ -3125,7 +3125,7 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
                                        triangles = tri[0],
                                        quadrilaterals = quad[0],
                                        crs = crs)
-    elif len(tri)>0 and len(quad)==0:
+    if len(tri)>0 and len(quad)==0:
         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
                                        triangles = tri[0],
                                        crs = crs)
@@ -3162,9 +3162,9 @@ def quads_from_tri(msht) -> jigsaw_msh_t:
     ang_chk = calc_el_angles(msht)[0][0]
     el = msht.tria3['index']
 
-    try:
+    if len(msht.quad4['index']) > 0:
         el_q = msht.quad4['index']
-    except:
+    else:
         el_q = []
 
     # Finds the idx of the vertices closes to 90 deg

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3102,9 +3102,10 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
 
         if len(verts) == 4:
             (tr_idx, br_idx) = rightMost_idx
-            return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
+            ord = np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
         if len(verts) == 3:
-            return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
+            ord = np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
+        return ord
 
     #order all element's nodes counterclockwise
     tri,quad=[],[]
@@ -3114,8 +3115,8 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
         if len(el) > 0:
             ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
             ordered_el = np.zeros(el.shape,dtype="int")
-            for i in range(len(ordered_el)):
-                ordered_el[i] = el[i][ordered_idx[i]]
+            for i,e in enumerate(ordered_el):
+                ordered_el[i] = el[i][e]
             if etype == 'tria3':
                 tri.append(ordered_el)
             if etype == 'quad4':

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2993,3 +2993,224 @@ def merge_overlapping_meshes(all_msht: list,
     msht_combined = cleanup_folded_bound_el(msht_combined)
 
     return msht_combined
+
+
+
+def calc_el_angles(msht):
+    '''
+    Adapted from: https://github.com/SorooshMani-NOAA/river-in-mesh/tree/main/river_in_mesh
+
+    Calculates the internal angle of each node for element (triangular or quadrangular)
+
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
+
+    Returns
+    -------
+    np.array
+        internal angles of each element
+    
+    Notes
+
+    -----
+    '''
+
+    tri,quad=[],[]
+    for etype in ELEM_2D_TYPES[:-1]:
+        el = getattr(msht, etype)['index']
+        coord_verts = msht.vert2['coord'][el]
+
+        tria_verts = coord_verts[:,:3]
+        sides = np.linalg.norm(
+            tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+            axis=2
+        )
+
+        ang_0_0 = np.degrees(np.arccos(
+            (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+                / (2 * sides[:, 1] * sides[:, 2])
+        ))
+        ang_1_0 = np.degrees(np.arccos(
+            (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+                / (2 * sides[:, 0] * sides[:, 2])
+        ))
+        ang_2_0 = 180 - (ang_0_0 + ang_1_0)
+
+        if etype == 'tria3' and len(el) > 0:
+            tri.append(np.vstack((ang_1_0, ang_2_0, ang_0_0)).T)
+        if etype == 'quad4' and len(el) > 0:
+            tria_verts = coord_verts[:,[2,3,0]]
+            sides = np.linalg.norm(
+                tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+                axis=2
+            )
+
+            ang_0_1 = np.degrees(np.arccos(
+                (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+                    / (2 * sides[:, 1] * sides[:, 2])
+            ))
+            ang_1_1 = np.degrees(np.arccos(
+                (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+                    / (2 * sides[:, 0] * sides[:, 2])
+            ))
+            ang_2_1 = 180 - (ang_0_1 + ang_1_1)
+
+            quad.append(np.vstack(((ang_1_0+ang_0_1), ang_2_0,
+                                   (ang_0_0+ang_1_1), ang_2_1)).T)
+
+    return np.array(tri),np.array(quad)
+
+
+def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
+    '''
+    Order mesh nodes counterclockwise (triangles and quads)
+    based on the coordinates
+
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
+        mesh with nodes out of order
+
+    Returns
+    -------
+    jigsawpy.msh_t.jigsaw_msh_t
+    -------
+    np.array
+        mesh whose nodes within each element are oriented counterclockwise 
+    
+    Notes
+    -----
+    '''
+
+    def order_nodes(verts):
+        '''
+        Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
+        '''
+
+        xSorted_idx = np.argsort(verts[:, 0])
+        xSorted = verts[xSorted_idx, :]
+
+        leftMost = xSorted[:2, :]
+        leftMost_idx = xSorted_idx[:2]
+        rightMost = xSorted[2:, :]
+        rightMost_idx = xSorted_idx[2:]
+
+        leftMost_idx = leftMost_idx[np.argsort(leftMost[:, 1])]
+        (tl_idx, bl_idx) = leftMost_idx
+
+        rightMost_idx = rightMost_idx[np.argsort(rightMost[:, 1])]
+
+        if len(verts) == 4:
+            (tr_idx, br_idx) = rightMost_idx
+            return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
+        if len(verts) == 3:
+            return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
+
+    #order all element's nodes counterclockwise
+    tri,quad=[],[]
+    coord_verts = msht.vert2['coord']
+    for etype in ELEM_2D_TYPES[:-1]:
+        el = getattr(msht, etype)['index']
+        if len(el) > 0:
+            ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
+            ordered_el = np.zeros(el.shape,dtype="int")
+            for i in range(len(ordered_el)):
+                ordered_el[i] = el[i][ordered_idx[i]]
+            if etype == 'tria3':
+                tri.append(ordered_el)
+            if etype == 'quad4':
+                quad.append(ordered_el)
+    if len(tri)>0 and len(quad)>0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       triangles = tri[0],
+                                       quadrilaterals = quad[0],
+                                       crs = crs)
+    elif len(tri)>0 and len(quad)==0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       triangles = tri[0],
+                                       crs = crs)
+    if len(tri)==0 and len(quad)>0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       quadrilaterals = quad[0],
+                                       crs = crs)
+
+    return mesh_ordered
+
+
+def quads_from_tri(msht) -> jigsaw_msh_t:
+    """
+    Partially adapted from:
+    https://stackoverflow.com/questions/69605766/find-position-of-duplicate-elements-in-list
+
+    Combines all triangles that share vertices that are not right angles.
+    right angles is defined as the internal angle closest to 90deg
+
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
+        triangular mesh
+
+    Returns
+    -------
+    jigsawpy.msh_t.jigsaw_msh_t
+        quadrangular + triangular mesh
+    
+    Notes
+    -----
+    """
+
+    ang_chk = calc_el_angles(msht)[0][0]
+    el = msht.tria3['index']
+
+    try:
+        el_q = msht.quad4['index']
+    except:
+        el_q = []
+
+    # Finds the idx of the vertices closes to 90 deg
+    # Then, creates an array of non right angle vertices (shared)
+    idx_of_closest = np.abs(ang_chk - 90).argmin(axis=1)
+    # right = np.array([el[row,column] for row,column in enumerate(idx_of_closest)])
+    shared = np.array([np.delete(el[row],column) for \
+                       row,column in enumerate(idx_of_closest)])
+    shared.sort()
+
+    #Creates a dict of all elements that share 2 non-right angle vertices
+    duplicates = defaultdict(list)
+    for i, number in enumerate(shared):
+        duplicates[str(number)].append(i)
+
+    result = {key: value for key, value in duplicates.items() if len(value) > 1}
+
+    # separte the triangles to then be merged back to the quads
+    tris_drop=[]
+    for idxs in result.values():
+        tris_drop.append(idxs) 
+    tris_drop = np.array(tris_drop).ravel()
+    tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
+
+    # combines all triangles that share 2 non-right angle vertices
+    # the quads array is composed of 2 right angle nodes (idx_of_closest)
+    # and 2 shared nodes (result)
+    quads=[]
+    for idxs in result.values():
+        quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
+    
+    quads = np.array(quads)
+    coords = msht.vert2['coord']
+
+    msht_q = msht_from_numpy(coordinates = coords,
+                             triangles = tris,
+                             quadrilaterals = quads)
+
+    if len(el_q) > 0:
+        msht_previous_quads = msht_from_numpy(coordinates = coords,
+                                              quadrilaterals = el_q)
+        msht_q = merge_neighboring_meshes(msht_previous_quads,msht_q)
+
+    msht_q = order_mesh(msht_q)
+    cleanup_duplicates(msht_q)
+    put_id_tags(msht_q)
+
+    return msht_q

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3188,8 +3188,8 @@ def quads_from_tri(msht) -> jigsaw_msh_t:
     tris_drop=[]
     for idxs in result.values():
         tris_drop.append(idxs)
-    tris_drop = np.array(tris_drop, dtype="int").ravel()
-    tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
+    tris_drop = np.array(tris_drop, dtype="int")
+    tris = np.delete(msht.tria3['index'], tris_drop.ravel(),axis=0)
 
     # combines all triangles that share 2 non-right angle vertices
     # the quads array is composed of 2 right angle nodes (idx_of_closest)

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3082,6 +3082,7 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
     -----
     '''
 
+    mesh_ordered=[]
     def order_nodes(verts):
         '''
         Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
@@ -3102,10 +3103,10 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
 
         if len(verts) == 4:
             (tr_idx, br_idx) = rightMost_idx
-            ord = np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
+            order = np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
         if len(verts) == 3:
-            ord = np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
-        return ord
+            order = np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
+        return order
 
     #order all element's nodes counterclockwise
     tri,quad=[],[]

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -2995,221 +2995,221 @@ def merge_overlapping_meshes(all_msht: list,
     return msht_combined
 
 
-# def calc_el_angles(msht):
-#     '''
-#     Adapted from: https://github.com/SorooshMani-NOAA/river-in-mesh/tree/main/river_in_mesh
+def calc_el_angles(msht):
+    '''
+    Adapted from: https://github.com/SorooshMani-NOAA/river-in-mesh/tree/main/river_in_mesh
 
-#     Calculates the internal angle of each node for element (triangular or quadrangular)
+    Calculates the internal angle of each node for element (triangular or quadrangular)
 
-#     Parameters
-#     ----------
-#     msht : jigsawpy.msh_t.jigsaw_msh_t
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
 
-#     Returns
-#     -------
-#     np.array
-#         internal angles of each element
+    Returns
+    -------
+    np.array
+        internal angles of each element
 
-#     Notes
+    Notes
 
-#     -----
-#     '''
+    -----
+    '''
 
-#     tri,quad=[],[]
-#     for etype in ELEM_2D_TYPES[:-1]:
-#         el = getattr(msht, etype)['index']
-#         coord_verts = msht.vert2['coord'][el]
+    tri,quad=[],[]
+    for etype in ELEM_2D_TYPES[:-1]:
+        el = getattr(msht, etype)['index']
+        coord_verts = msht.vert2['coord'][el]
 
-#         tria_verts = coord_verts[:,:3]
-#         sides = np.linalg.norm(
-#             tria_verts - np.roll(tria_verts, shift=-1, axis=1),
-#             axis=2
-#         )
+        tria_verts = coord_verts[:,:3]
+        sides = np.linalg.norm(
+            tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+            axis=2
+        )
 
-#         ang_0_0 = np.degrees(np.arccos(
-#             (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
-#                 / (2 * sides[:, 1] * sides[:, 2])
-#         ))
-#         ang_1_0 = np.degrees(np.arccos(
-#             (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
-#                 / (2 * sides[:, 0] * sides[:, 2])
-#         ))
-#         ang_2_0 = 180 - (ang_0_0 + ang_1_0)
+        ang_0_0 = np.degrees(np.arccos(
+            (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+                / (2 * sides[:, 1] * sides[:, 2])
+        ))
+        ang_1_0 = np.degrees(np.arccos(
+            (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+                / (2 * sides[:, 0] * sides[:, 2])
+        ))
+        ang_2_0 = 180 - (ang_0_0 + ang_1_0)
 
-#         if etype == 'tria3' and len(el) > 0:
-#             tri.append(np.vstack((ang_1_0, ang_2_0, ang_0_0)).T)
-#         if etype == 'quad4' and len(el) > 0:
-#             tria_verts = coord_verts[:,[2,3,0]]
-#             sides = np.linalg.norm(
-#                 tria_verts - np.roll(tria_verts, shift=-1, axis=1),
-#                 axis=2
-#             )
+        if etype == 'tria3' and len(el) > 0:
+            tri.append(np.vstack((ang_1_0, ang_2_0, ang_0_0)).T)
+        if etype == 'quad4' and len(el) > 0:
+            tria_verts = coord_verts[:,[2,3,0]]
+            sides = np.linalg.norm(
+                tria_verts - np.roll(tria_verts, shift=-1, axis=1),
+                axis=2
+            )
 
-#             ang_0_1 = np.degrees(np.arccos(
-#                 (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
-#                     / (2 * sides[:, 1] * sides[:, 2])
-#             ))
-#             ang_1_1 = np.degrees(np.arccos(
-#                 (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
-#                     / (2 * sides[:, 0] * sides[:, 2])
-#             ))
-#             ang_2_1 = 180 - (ang_0_1 + ang_1_1)
+            ang_0_1 = np.degrees(np.arccos(
+                (sides[:, 1]**2 + sides[:, 2]**2 - sides[:, 0]**2)
+                    / (2 * sides[:, 1] * sides[:, 2])
+            ))
+            ang_1_1 = np.degrees(np.arccos(
+                (sides[:, 0]**2 + sides[:, 2]**2 - sides[:, 1]**2)
+                    / (2 * sides[:, 0] * sides[:, 2])
+            ))
+            ang_2_1 = 180 - (ang_0_1 + ang_1_1)
 
-#             quad.append(np.vstack(((ang_1_0+ang_0_1), ang_2_0,
-#                                    (ang_0_0+ang_1_1), ang_2_1)).T)
+            quad.append(np.vstack(((ang_1_0+ang_0_1), ang_2_0,
+                                   (ang_0_0+ang_1_1), ang_2_1)).T)
 
-#     return np.array(tri),np.array(quad)
-
-
-# def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
-#     '''
-#     Order mesh nodes counterclockwise (triangles and quads)
-#     based on the coordinates
-
-#     Parameters
-#     ----------
-#     msht : jigsawpy.msh_t.jigsaw_msh_t
-#         mesh with nodes out of order
-
-#     Returns
-#     -------
-#     jigsawpy.msh_t.jigsaw_msh_t
-#     -------
-#     np.array
-#         mesh whose nodes within each element are oriented counterclockwise
-
-#     Notes
-#     -----
-#     '''
-
-#     def order_nodes(verts):
-#         '''
-#         Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
-#         '''
-
-#         xSorted_idx = np.argsort(verts[:, 0])
-#         xSorted = verts[xSorted_idx, :]
-
-#         leftMost = xSorted[:2, :]
-#         leftMost_idx = xSorted_idx[:2]
-#         rightMost = xSorted[2:, :]
-#         rightMost_idx = xSorted_idx[2:]
-
-#         leftMost_idx = leftMost_idx[np.argsort(leftMost[:, 1])]
-#         (tl_idx, bl_idx) = leftMost_idx
-
-#         rightMost_idx = rightMost_idx[np.argsort(rightMost[:, 1])]
-
-#         if len(verts) == 4:
-#             (tr_idx, br_idx) = rightMost_idx
-#             return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
-#         if len(verts) == 3:
-#             return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
-
-#     #order all element's nodes counterclockwise
-#     tri,quad=[],[]
-#     coord_verts = msht.vert2['coord']
-#     for etype in ELEM_2D_TYPES[:-1]:
-#         el = getattr(msht, etype)['index']
-#         if len(el) > 0:
-#             ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
-#             ordered_el = np.zeros(el.shape,dtype="int")
-#             for i in range(len(ordered_el)):
-#                 ordered_el[i] = el[i][ordered_idx[i]]
-#             if etype == 'tria3':
-#                 tri.append(ordered_el)
-#             if etype == 'quad4':
-#                 quad.append(ordered_el)
-#     if len(tri)>0 and len(quad)>0:
-#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-#                                        triangles = tri[0],
-#                                        quadrilaterals = quad[0],
-#                                        crs = crs)
-#     elif len(tri)>0 and len(quad)==0:
-#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-#                                        triangles = tri[0],
-#                                        crs = crs)
-#     if len(tri)==0 and len(quad)>0:
-#         mesh_ordered = msht_from_numpy(coordinates = coord_verts,
-#                                        quadrilaterals = quad[0],
-#                                        crs = crs)
-
-#     return mesh_ordered
+    return np.array(tri),np.array(quad)
 
 
-# def quads_from_tri(msht) -> jigsaw_msh_t:
-#     """
-#     Partially adapted from:
-#     https://stackoverflow.com/questions/69605766/find-position-of-duplicate-elements-in-list
+def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
+    '''
+    Order mesh nodes counterclockwise (triangles and quads)
+    based on the coordinates
 
-#     Combines all triangles that share vertices that are not right angles.
-#     right angles is defined as the internal angle closest to 90deg
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
+        mesh with nodes out of order
 
-#     Parameters
-#     ----------
-#     msht : jigsawpy.msh_t.jigsaw_msh_t
-#         triangular mesh
+    Returns
+    -------
+    jigsawpy.msh_t.jigsaw_msh_t
+    -------
+    np.array
+        mesh whose nodes within each element are oriented counterclockwise
 
-#     Returns
-#     -------
-#     jigsawpy.msh_t.jigsaw_msh_t
-#         quadrangular + triangular mesh
+    Notes
+    -----
+    '''
 
-#     Notes
-#     -----
-#     """
+    def order_nodes(verts):
+        '''
+        Adapted from: https://gist.github.com/flashlib/e8261539915426866ae910d55a3f9959
+        '''
 
-#     ang_chk = calc_el_angles(msht)[0][0]
-#     el = msht.tria3['index']
+        xSorted_idx = np.argsort(verts[:, 0])
+        xSorted = verts[xSorted_idx, :]
 
-#     try:
-#         el_q = msht.quad4['index']
-#     except:
-#         el_q = []
+        leftMost = xSorted[:2, :]
+        leftMost_idx = xSorted_idx[:2]
+        rightMost = xSorted[2:, :]
+        rightMost_idx = xSorted_idx[2:]
 
-#     # Finds the idx of the vertices closes to 90 deg
-#     # Then, creates an array of non right angle vertices (shared)
-#     idx_of_closest = np.abs(ang_chk - 90).argmin(axis=1)
-#     # right = np.array([el[row,column] for row,column in enumerate(idx_of_closest)])
-#     shared = np.array([np.delete(el[row],column) for \
-#                        row,column in enumerate(idx_of_closest)])
-#     shared.sort()
+        leftMost_idx = leftMost_idx[np.argsort(leftMost[:, 1])]
+        (tl_idx, bl_idx) = leftMost_idx
 
-#     #Creates a dict of all elements that share 2 non-right angle vertices
-#     duplicates = defaultdict(list)
-#     for i, number in enumerate(shared):
-#         duplicates[str(number)].append(i)
+        rightMost_idx = rightMost_idx[np.argsort(rightMost[:, 1])]
 
-#     result = {key: value for key, value in duplicates.items() if len(value) > 1}
+        if len(verts) == 4:
+            (tr_idx, br_idx) = rightMost_idx
+            return np.array([tl_idx, tr_idx, br_idx, bl_idx], dtype="int")
+        if len(verts) == 3:
+            return np.array([tl_idx, rightMost_idx[0], bl_idx], dtype="int")
 
-#     # separte the triangles to then be merged back to the quads
-#     tris_drop=[]
-#     for idxs in result.values():
-#         tris_drop.append(idxs)
-#     tris_drop = np.array(tris_drop).ravel()
-#     tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
+    #order all element's nodes counterclockwise
+    tri,quad=[],[]
+    coord_verts = msht.vert2['coord']
+    for etype in ELEM_2D_TYPES[:-1]:
+        el = getattr(msht, etype)['index']
+        if len(el) > 0:
+            ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
+            ordered_el = np.zeros(el.shape,dtype="int")
+            for i in range(len(ordered_el)):
+                ordered_el[i] = el[i][ordered_idx[i]]
+            if etype == 'tria3':
+                tri.append(ordered_el)
+            if etype == 'quad4':
+                quad.append(ordered_el)
+    if len(tri)>0 and len(quad)>0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       triangles = tri[0],
+                                       quadrilaterals = quad[0],
+                                       crs = crs)
+    elif len(tri)>0 and len(quad)==0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       triangles = tri[0],
+                                       crs = crs)
+    if len(tri)==0 and len(quad)>0:
+        mesh_ordered = msht_from_numpy(coordinates = coord_verts,
+                                       quadrilaterals = quad[0],
+                                       crs = crs)
 
-#     # combines all triangles that share 2 non-right angle vertices
-#     # the quads array is composed of 2 right angle nodes (idx_of_closest)
-#     # and 2 shared nodes (result)
-#     quads=[]
-#     for idxs in result.values():
-#         quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
+    return mesh_ordered
 
-#     quads = np.array(quads)
-#     coords = msht.vert2['coord']
 
-#     msht_q = msht_from_numpy(coordinates = coords,
-#                              triangles = tris,
-#                              quadrilaterals = quads)
+def quads_from_tri(msht) -> jigsaw_msh_t:
+    """
+    Partially adapted from:
+    https://stackoverflow.com/questions/69605766/find-position-of-duplicate-elements-in-list
 
-#     if len(el_q) > 0:
-#         msht_previous_quads = msht_from_numpy(coordinates = coords,
-#                                               quadrilaterals = el_q)
-#         msht_q = merge_neighboring_meshes(msht_previous_quads,msht_q)
+    Combines all triangles that share vertices that are not right angles.
+    right angles is defined as the internal angle closest to 90deg
 
-#     msht_q = order_mesh(msht_q)
-#     cleanup_duplicates(msht_q)
-#     put_id_tags(msht_q)
+    Parameters
+    ----------
+    msht : jigsawpy.msh_t.jigsaw_msh_t
+        triangular mesh
 
-#     return msht_q
+    Returns
+    -------
+    jigsawpy.msh_t.jigsaw_msh_t
+        quadrangular + triangular mesh
+
+    Notes
+    -----
+    """
+
+    ang_chk = calc_el_angles(msht)[0][0]
+    el = msht.tria3['index']
+
+    try:
+        el_q = msht.quad4['index']
+    except:
+        el_q = []
+
+    # Finds the idx of the vertices closes to 90 deg
+    # Then, creates an array of non right angle vertices (shared)
+    idx_of_closest = np.abs(ang_chk - 90).argmin(axis=1)
+    # right = np.array([el[row,column] for row,column in enumerate(idx_of_closest)])
+    shared = np.array([np.delete(el[row],column) for \
+                       row,column in enumerate(idx_of_closest)])
+    shared.sort()
+
+    #Creates a dict of all elements that share 2 non-right angle vertices
+    duplicates = defaultdict(list)
+    for i, number in enumerate(shared):
+        duplicates[str(number)].append(i)
+
+    result = {key: value for key, value in duplicates.items() if len(value) > 1}
+
+    # separte the triangles to then be merged back to the quads
+    tris_drop=[]
+    for idxs in result.values():
+        tris_drop.append(idxs)
+    tris_drop = np.array(tris_drop).ravel()
+    tris = np.delete(msht.tria3['index'], tris_drop,axis=0)
+
+    # combines all triangles that share 2 non-right angle vertices
+    # the quads array is composed of 2 right angle nodes (idx_of_closest)
+    # and 2 shared nodes (result)
+    quads=[]
+    for idxs in result.values():
+        quads.append(np.unique(np.concatenate([el[idxs[0]],el[idxs[1]]])))
+
+    quads = np.array(quads)
+    coords = msht.vert2['coord']
+
+    msht_q = msht_from_numpy(coordinates = coords,
+                             triangles = tris,
+                             quadrilaterals = quads)
+
+    if len(el_q) > 0:
+        msht_previous_quads = msht_from_numpy(coordinates = coords,
+                                              quadrilaterals = el_q)
+        msht_q = merge_neighboring_meshes(msht_previous_quads,msht_q)
+
+    msht_q = order_mesh(msht_q)
+    cleanup_duplicates(msht_q)
+    put_id_tags(msht_q)
+
+    return msht_q

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -3116,7 +3116,7 @@ def order_mesh(msht,crs=CRS.from_epsg(4326)) -> jigsaw_msh_t:
         if len(el) > 0:
             ordered_idx = np.array([order_nodes(coord_verts[i]) for i in el])
             ordered_el = np.zeros(el.shape,dtype="int")
-            for i,e in enumerate(ordered_el):
+            for i,e in enumerate(ordered_idx):
                 ordered_el[i] = el[i][e]
             if etype == 'tria3':
                 tri.append(ordered_el)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = '>=3.9' # 3.8 -> scipy
 dependencies = [
-    "colored-traceback", "fiona", "geopandas"<=0.14.4,
+    "colored-traceback", "fiona", "geopandas<=0.14.4",
     "jigsawpy", "matplotlib>=3.8", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
     "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = '>=3.9' # 3.8 -> scipy
 dependencies = [
-    "colored-traceback", "fiona", "geopandas",
+    "colored-traceback", "fiona", "geopandas"<=0.14.4,
     "jigsawpy", "matplotlib>=3.8", "netCDF4", "numba",
     "numpy>=1.21", # introduce npt.NDArray
     "pyarrow", "rtree", "pyproj>=3.0", "rasterio", "scipy",

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -47,6 +47,70 @@ class SetUp(unittest.TestCase):
             assert patch == line[3]
 
 
+class TritoQuad(unittest.TestCase):
+    def setUp(self):
+
+        self.in_verts = [
+            [0, 5],
+            [0, 0],
+            [.5, 3],
+            [3, 3],
+            [2.5, 5],
+            [1, 0],
+            [3, .5],
+            [0, 7],
+            [2.5, 7],
+            [0, 9],
+            [2.5, 9],
+        ]
+        self.in_tria = [
+            [0, 1, 2],
+            [0, 2, 3],
+            [0, 3, 4],
+            [5, 6, 2],
+            [5, 2, 1],
+            [2, 6, 3],
+        ]
+        self.in_quad = [
+            [0, 7, 4, 8],
+            [7, 9, 10, 8],
+        ]
+
+    def test_calc_el_angles(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
+        self.assertEqual(utils.calc_el_angles(out_msht)[0][0][-1].astype(int),
+                         np.array([45, 44, 90]))
+
+        self.assertEqual(utils.calc_el_angles(out_msht)[-1][0][-1],
+                         np.array([90., 90., 90., 90.]))
+
+    def order_mesh(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
+        self.assertEqual(utils.order_mesh(out_msht).quad4['index'][0],
+                         np.array([0, 4, 8, 7]))
+
+    def quads_from_tri(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
+
+        out_msht_ord = utils.order_mesh(out_msht)
+        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+
+        self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
+        self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
+
+
 class SmallAreaElements(unittest.TestCase):
 
     def test_filter_el_by_area(self):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -103,23 +103,23 @@ class TritoQuad(unittest.TestCase):
             np.all(utils.order_mesh(out_msht).quad4['index'] == np.array([[ 0,  4,  8,  7],[ 7,  8, 10,  9]]))
         )
 
-    # def test_quads_from_tri(self):
-    #     out_msht = utils.msht_from_numpy(
-    #         coordinates=self.in_verts,
-    #         triangles=self.in_tria,
-    #         quadrilaterals=self.in_quad
-    #     )
+    def test_quads_from_tri(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
 
-    #     self.assertIsInstance(out_msht, jigsaw_msh_t)
+        self.assertIsInstance(out_msht, jigsaw_msh_t)
 
-    #     out_msht_ord = utils.order_mesh(out_msht)
-    #     self.assertIsInstance(out_msht_ord, jigsaw_msh_t)
+        out_msht_ord = utils.order_mesh(out_msht)
+        self.assertIsInstance(out_msht_ord, jigsaw_msh_t)
 
-    #     out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
-    #     self.assertIsInstance(out_msht_ord_q, jigsaw_msh_t)
+        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+        self.assertIsInstance(out_msht_ord_q, jigsaw_msh_t)
 
-    #     self.assertEqual(len(out_msht_ord_q.tria3), 2)
-    #     self.assertEqual(len(out_msht_ord_q.quad4), 4)
+        self.assertEqual(len(out_msht_ord_q.tria3), 2)
+        self.assertEqual(len(out_msht_ord_q.quad4), 4)
 
 
 class SmallAreaElements(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -47,70 +47,70 @@ class SetUp(unittest.TestCase):
             assert patch == line[3]
 
 
-# class TritoQuad(unittest.TestCase):
-#     def setUp(self):
+class TritoQuad(unittest.TestCase):
+    def setUp(self):
 
-#         self.in_verts = [
-#             [0, 5],
-#             [0, 0],
-#             [.5, 3],
-#             [3, 3],
-#             [2.5, 5],
-#             [1, 0],
-#             [3, .5],
-#             [0, 7],
-#             [2.5, 7],
-#             [0, 9],
-#             [2.5, 9],
-#         ]
-#         self.in_tria = [
-#             [0, 1, 2],
-#             [0, 2, 3],
-#             [0, 3, 4],
-#             [5, 6, 2],
-#             [5, 2, 1],
-#             [2, 6, 3],
-#         ]
-#         self.in_quad = [
-#             [0, 7, 4, 8],
-#             [7, 9, 10, 8],
-#         ]
+        self.in_verts = [
+            [0, 5],
+            [0, 0],
+            [.5, 3],
+            [3, 3],
+            [2.5, 5],
+            [1, 0],
+            [3, .5],
+            [0, 7],
+            [2.5, 7],
+            [0, 9],
+            [2.5, 9],
+        ]
+        self.in_tria = [
+            [0, 1, 2],
+            [0, 2, 3],
+            [0, 3, 4],
+            [5, 6, 2],
+            [5, 2, 1],
+            [2, 6, 3],
+        ]
+        self.in_quad = [
+            [0, 7, 4, 8],
+            [7, 9, 10, 8],
+        ]
 
-#     def test_calc_el_angles(self):
-#         out_msht = utils.msht_from_numpy(
-#             coordinates=self.in_verts,
-#             triangles=self.in_tria,
-#             quadrilaterals=self.in_quad
-#         )
-#         self.assertTrue(
-#             np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
-#         )
-#         self.assertTrue(
-#             np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
-#         )
+    def test_calc_el_angles(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
+        self.assertTrue(
+            np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
+        )
+        self.assertTrue(
+            np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
+        )
 
-#     def order_mesh(self):
-#         out_msht = utils.msht_from_numpy(
-#             coordinates=self.in_verts,
-#             triangles=self.in_tria,
-#             quadrilaterals=self.in_quad
-#         )
-#         self.assertTrue(
-#             np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
-#         )
+    def order_mesh(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
+        self.assertTrue(
+            np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
+        )
 
-#     def quads_from_tri(self):
-#         out_msht = utils.msht_from_numpy(
-#             coordinates=self.in_verts,
-#             triangles=self.in_tria,
-#             quadrilaterals=self.in_quad
-#         )
+    def quads_from_tri(self):
+        out_msht = utils.msht_from_numpy(
+            coordinates=self.in_verts,
+            triangles=self.in_tria,
+            quadrilaterals=self.in_quad
+        )
 
-#         out_msht_ord = utils.order_mesh(out_msht)
-#         out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+        out_msht_ord = utils.order_mesh(out_msht)
+        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
 
-#         self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
-#         self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
+        self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
+        self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
 
 
 class SmallAreaElements(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -89,7 +89,7 @@ class TritoQuad(unittest.TestCase):
             np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
         )
 
-    def order_mesh(self):
+    def test_order_mesh(self):
         out_msht = utils.msht_from_numpy(
             coordinates=self.in_verts,
             triangles=self.in_tria,
@@ -99,7 +99,7 @@ class TritoQuad(unittest.TestCase):
             np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
         )
 
-    def quads_from_tri(self):
+    def test_quads_from_tri(self):
         out_msht = utils.msht_from_numpy(
             coordinates=self.in_verts,
             triangles=self.in_tria,

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -103,23 +103,23 @@ class TritoQuad(unittest.TestCase):
             np.all(utils.order_mesh(out_msht).quad4['index'][0].astype(int) == np.array([0, 4, 8, 7]))
         )
 
-    def test_quads_from_tri(self):
-        out_msht = utils.msht_from_numpy(
-            coordinates=self.in_verts,
-            triangles=self.in_tria,
-            quadrilaterals=self.in_quad
-        )
+    # def test_quads_from_tri(self):
+    #     out_msht = utils.msht_from_numpy(
+    #         coordinates=self.in_verts,
+    #         triangles=self.in_tria,
+    #         quadrilaterals=self.in_quad
+    #     )
 
-        self.assertIsInstance(out_msht, jigsaw_msh_t)
+    #     self.assertIsInstance(out_msht, jigsaw_msh_t)
 
-        out_msht_ord = utils.order_mesh(out_msht)
-        self.assertIsInstance(out_msht_ord, jigsaw_msh_t)
+    #     out_msht_ord = utils.order_mesh(out_msht)
+    #     self.assertIsInstance(out_msht_ord, jigsaw_msh_t)
 
-        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
-        self.assertIsInstance(out_msht_ord_q, jigsaw_msh_t)
+    #     out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+    #     self.assertIsInstance(out_msht_ord_q, jigsaw_msh_t)
 
-        self.assertEqual(len(out_msht_ord_q.tria3), 2)
-        self.assertEqual(len(out_msht_ord_q.quad4), 4)
+    #     self.assertEqual(len(out_msht_ord_q.tria3), 2)
+    #     self.assertEqual(len(out_msht_ord_q.quad4), 4)
 
 
 class SmallAreaElements(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -82,6 +82,8 @@ class TritoQuad(unittest.TestCase):
             triangles=self.in_tria,
             quadrilaterals=self.in_quad
         )
+
+        self.assertIsInstance(out_msht, jigsaw_msh_t)
         self.assertTrue(
             np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
         )
@@ -95,6 +97,8 @@ class TritoQuad(unittest.TestCase):
             triangles=self.in_tria,
             quadrilaterals=self.in_quad
         )
+
+        self.assertIsInstance(out_msht, jigsaw_msh_t)
         self.assertTrue(
             np.all(utils.order_mesh(out_msht).quad4['index'][0].astype(int) == np.array([0, 4, 8, 7]))
         )
@@ -106,11 +110,16 @@ class TritoQuad(unittest.TestCase):
             quadrilaterals=self.in_quad
         )
 
-        out_msht_ord = utils.order_mesh(out_msht)
-        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+        self.assertIsInstance(out_msht, jigsaw_msh_t)
 
-        self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
-        self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
+        out_msht_ord = utils.order_mesh(out_msht)
+        self.assertIsInstance(out_msht_ord, jigsaw_msh_t)
+
+        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+        self.assertIsInstance(out_msht_ord_q, jigsaw_msh_t)
+
+        self.assertEqual(len(out_msht_ord_q.tria3), 2)
+        self.assertEqual(len(out_msht_ord_q.quad4), 4)
 
 
 class SmallAreaElements(unittest.TestCase):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -100,7 +100,7 @@ class TritoQuad(unittest.TestCase):
 
         self.assertIsInstance(out_msht, jigsaw_msh_t)
         self.assertTrue(
-            np.all(utils.order_mesh(out_msht).quad4['index'][0].astype(int) == np.array([0, 4, 8, 7]))
+            np.all(utils.order_mesh(out_msht).quad4['index'] == np.array([[ 0,  4,  8,  7],[ 7,  8, 10,  9]]))
         )
 
     # def test_quads_from_tri(self):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -96,7 +96,7 @@ class TritoQuad(unittest.TestCase):
             quadrilaterals=self.in_quad
         )
         self.assertTrue(
-            np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
+            np.all(utils.order_mesh(out_msht).quad4['index'][0].astype(int) == np.array([0, 4, 8, 7]))
         )
 
     def test_quads_from_tri(self):

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -82,11 +82,12 @@ class TritoQuad(unittest.TestCase):
             triangles=self.in_tria,
             quadrilaterals=self.in_quad
         )
-        self.assertEqual(utils.calc_el_angles(out_msht)[0][0][-1].astype(int),
-                         np.array([45, 44, 90]))
-
-        self.assertEqual(utils.calc_el_angles(out_msht)[-1][0][-1],
-                         np.array([90., 90., 90., 90.]))
+        self.assertTrue(
+            np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
+        )
+        self.assertTrue(
+            np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
+        )
 
     def order_mesh(self):
         out_msht = utils.msht_from_numpy(
@@ -94,8 +95,9 @@ class TritoQuad(unittest.TestCase):
             triangles=self.in_tria,
             quadrilaterals=self.in_quad
         )
-        self.assertEqual(utils.order_mesh(out_msht).quad4['index'][0],
-                         np.array([0, 4, 8, 7]))
+        self.assertTrue(
+            np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
+        )
 
     def quads_from_tri(self):
         out_msht = utils.msht_from_numpy(

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -47,70 +47,70 @@ class SetUp(unittest.TestCase):
             assert patch == line[3]
 
 
-class TritoQuad(unittest.TestCase):
-    def setUp(self):
+# class TritoQuad(unittest.TestCase):
+#     def setUp(self):
 
-        self.in_verts = [
-            [0, 5],
-            [0, 0],
-            [.5, 3],
-            [3, 3],
-            [2.5, 5],
-            [1, 0],
-            [3, .5],
-            [0, 7],
-            [2.5, 7],
-            [0, 9],
-            [2.5, 9],
-        ]
-        self.in_tria = [
-            [0, 1, 2],
-            [0, 2, 3],
-            [0, 3, 4],
-            [5, 6, 2],
-            [5, 2, 1],
-            [2, 6, 3],
-        ]
-        self.in_quad = [
-            [0, 7, 4, 8],
-            [7, 9, 10, 8],
-        ]
+#         self.in_verts = [
+#             [0, 5],
+#             [0, 0],
+#             [.5, 3],
+#             [3, 3],
+#             [2.5, 5],
+#             [1, 0],
+#             [3, .5],
+#             [0, 7],
+#             [2.5, 7],
+#             [0, 9],
+#             [2.5, 9],
+#         ]
+#         self.in_tria = [
+#             [0, 1, 2],
+#             [0, 2, 3],
+#             [0, 3, 4],
+#             [5, 6, 2],
+#             [5, 2, 1],
+#             [2, 6, 3],
+#         ]
+#         self.in_quad = [
+#             [0, 7, 4, 8],
+#             [7, 9, 10, 8],
+#         ]
 
-    def test_calc_el_angles(self):
-        out_msht = utils.msht_from_numpy(
-            coordinates=self.in_verts,
-            triangles=self.in_tria,
-            quadrilaterals=self.in_quad
-        )
-        self.assertTrue(
-            np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
-        )
-        self.assertTrue(
-            np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
-        )
+#     def test_calc_el_angles(self):
+#         out_msht = utils.msht_from_numpy(
+#             coordinates=self.in_verts,
+#             triangles=self.in_tria,
+#             quadrilaterals=self.in_quad
+#         )
+#         self.assertTrue(
+#             np.all(utils.calc_el_angles(out_msht)[0][0][-1].astype(int) == np.array([45, 44, 90]))
+#         )
+#         self.assertTrue(
+#             np.all(utils.calc_el_angles(out_msht)[-1][0][-1] == np.array([90., 90., 90., 90.]))
+#         )
 
-    def order_mesh(self):
-        out_msht = utils.msht_from_numpy(
-            coordinates=self.in_verts,
-            triangles=self.in_tria,
-            quadrilaterals=self.in_quad
-        )
-        self.assertTrue(
-            np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
-        )
+#     def order_mesh(self):
+#         out_msht = utils.msht_from_numpy(
+#             coordinates=self.in_verts,
+#             triangles=self.in_tria,
+#             quadrilaterals=self.in_quad
+#         )
+#         self.assertTrue(
+#             np.all(utils.order_mesh(out_msht).quad4['index'][0] == np.array([0, 4, 8, 7]))
+#         )
 
-    def quads_from_tri(self):
-        out_msht = utils.msht_from_numpy(
-            coordinates=self.in_verts,
-            triangles=self.in_tria,
-            quadrilaterals=self.in_quad
-        )
+#     def quads_from_tri(self):
+#         out_msht = utils.msht_from_numpy(
+#             coordinates=self.in_verts,
+#             triangles=self.in_tria,
+#             quadrilaterals=self.in_quad
+#         )
 
-        out_msht_ord = utils.order_mesh(out_msht)
-        out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
+#         out_msht_ord = utils.order_mesh(out_msht)
+#         out_msht_ord_q = utils.quads_from_tri(out_msht_ord)
 
-        self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
-        self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
+#         self.assertEqual(len(out_msht_ord_q.tria3['index']), 2)
+#         self.assertEqual(len(out_msht_ord_q.quad4['index']), 4)
 
 
 class SmallAreaElements(unittest.TestCase):


### PR DESCRIPTION
functions added:
calc_el_angles(msht), for calculating the internal angles of each element (tri and quads)
order_mesh(msht_: returns the reordered mesh (counterclockwise)
quads_from_tri(msht): creates quads from triangular mesh

The tests for these new functions are under the new class: TritoQuad



The Functional errors were coming from the new geopandas: https://geopandas.org/en/stable/docs/changelog.html
that does not support shapely<2.0.0. Thus, the unary_union method is no longer supported (if I understood it correctly).
I changed the .toml to "geopandas<=0.14.4"
we might have to come up with a better solution later