### PR TITLE
refactor: Standardize meshdata attribute names

### DIFF
--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -2272,10 +2272,10 @@ class HfunCollector(BaseHfun):
         value = []
         offset = 0
         for hfun in collection:
-            index.append(hfun.triangles + offset)
-            coord.append(hfun.coord)
-            value.append(hfun.value.reshape(-1, 1))
-            offset += hfun.coord.shape[0]
+            index.append(hfun.tria + offset)
+            coord.append(hfun.coords)
+            value.append(hfun.values.reshape(-1, 1))
+            offset += hfun.coords.shape[0]
 
         composite_hfun = MeshData(
                 coords=np.vstack(coord),

--- a/ocsmesh/mesh/base.py
+++ b/ocsmesh/mesh/base.py
@@ -14,7 +14,7 @@ class BaseMesh:
     ----------
     meshdata : MeshData
         Refernece to underlying mesh object.
-    coord : array-like
+    coords : array-like
         Coordinates of mesh nodes.
 
     Methods
@@ -42,7 +42,7 @@ class BaseMesh:
         return self._meshdata
 
     @property
-    def coord(self) -> npt.NDArray[np.float32]:
+    def coords(self) -> npt.NDArray[np.float32]:
         """Read-only property for coordinates of mesh points
 
         Raises
@@ -57,3 +57,13 @@ class BaseMesh:
         """
 
         return self.meshdata.coords
+
+    @property
+    def coord(self) -> npt.NDArray[np.float32]:
+        """Deprecated. Use ``coords`` instead."""
+        warnings.warn(
+            "'coord' is deprecated, use 'coords' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.coords

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -266,8 +266,8 @@ class EuclideanMesh2D(EuclideanMesh):
         """
 
         output_type = 'polygon' if output_type is None else output_type
-        xmin, xmax = np.min(self.coord[:, 0]), np.max(self.coord[:, 0])
-        ymin, ymax = np.min(self.coord[:, 1]), np.max(self.coord[:, 1])
+        xmin, xmax = np.min(self.coords[:, 0]), np.max(self.coords[:, 0])
+        ymin, ymax = np.min(self.coords[:, 1]), np.max(self.coords[:, 1])
         crs = self.crs if crs is None else crs
         if crs is not None:
             if not self.crs.equals(crs):
@@ -543,9 +543,19 @@ class EuclideanMesh2D(EuclideanMesh):
         return self.meshdata.coords
 
     @property
-    def value(self):
+    def values(self):
         """Reference to underlying mesh values"""
         return self.meshdata.values
+
+    @property
+    def value(self):
+        """Deprecated. Use ``values`` instead."""
+        warnings.warn(
+            "'value' is deprecated, use 'values' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.values
 
     @property
     def bbox(self):
@@ -1056,7 +1066,7 @@ class Hull:
                 [quad[0], quad[1], quad[3]],
                 [quad[1], quad[2], quad[3]]
             ])
-        return Triangulation(self.mesh.coord[:, 0], self.mesh.coord[:, 1], triangles)
+        return Triangulation(self.mesh.coords[:, 0], self.mesh.coords[:, 1], triangles)
 
 
 
@@ -1161,10 +1171,10 @@ class Nodes:
         Returns
         -------
         array-like
-            Coordinates of the mesh nodes as returned by `BaseMesh.coord`
+            Coordinates of the mesh nodes as returned by `BaseMesh.coords`
         """
 
-        return self.mesh.coord
+        return self.mesh.coords
 
     def values(self):
         """Retrieve the values stored for mesh nodes
@@ -1466,8 +1476,8 @@ class Elements:
             triangles.append([quad[0], quad[1], quad[3]])
             triangles.append([quad[1], quad[2], quad[3]])
         return Triangulation(
-            self.mesh.coord[:, 0],
-            self.mesh.coord[:, 1],
+            self.mesh.coords[:, 0],
+            self.mesh.coords[:, 1],
             triangles)
 
     def area(self):
@@ -1526,7 +1536,7 @@ class Elements:
         for elem_id, elem_nd_ids in self().items():
             data.append({
                 'geometry': Polygon(
-                    self.mesh.coord[list(
+                    self.mesh.coords[list(
                         map(self.mesh.nodes.get_index_by_id, elem_nd_ids))]),
                 'id': elem_id})
         return gpd.GeoDataFrame(data, crs=self.mesh.crs)
@@ -1657,7 +1667,7 @@ class Boundaries:
                             'id': bnd_id,
                             "index_id": data['indexes'],
                             "indexes": indexes,
-                            'geometry': LineString(self.mesh.coord[indexes])
+                            'geometry': LineString(self.mesh.coords[indexes])
                             })
 
                 elif str(ibtype).endswith('1'):
@@ -1669,7 +1679,7 @@ class Boundaries:
                             'ibtype': ibtype,
                             "index_id": data['indexes'],
                             "indexes": indexes,
-                            'geometry': LineString(self.mesh.coord[indexes])
+                            'geometry': LineString(self.mesh.coords[indexes])
                             })
                 else:
                     for bnd_id, data in bnds.items():
@@ -1694,7 +1704,7 @@ class Boundaries:
                             'ibtype': ibtype,
                             "index_id": data['indexes'],
                             "indexes": indexes,
-                            'geometry': LineString(self.mesh.coord[indexes])
+                            'geometry': LineString(self.mesh.coords[indexes])
                             })
 
         crs = self.mesh.crs
@@ -1872,7 +1882,7 @@ class Boundaries:
         dry (its elevation is larger than or equal to the `threshold`).
         """
 
-        values = self.mesh.value
+        values = self.mesh.values
         if np.any(np.isnan(values)):
             raise ValueError(
                 "Mesh contains invalid values. Raster values must"

--- a/ocsmesh/mesh/mesh.py
+++ b/ocsmesh/mesh/mesh.py
@@ -152,16 +152,35 @@ class EuclideanMesh(BaseMesh):
 
 
     @property
-    def triangles(self):
+    def tria(self):
         """Reference to underlying mesh triangle element index array"""
 
         return self.meshdata.tria
 
     @property
-    def quads(self):
-        """Reference to underlying mesh quadrangle element index array"""
+    def triangles(self):
+        """Deprecated. Use ``tria`` instead."""
+        warnings.warn(
+            "'triangles' is deprecated, use 'tria' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.tria
 
+    @property
+    def quad(self):
+        """Reference to underlying mesh quadrangle element index array"""
         return self.meshdata.quad
+
+    @property
+    def quads(self):
+        """Deprecated. Use ``quad`` instead."""
+        warnings.warn(
+            "'quads' is deprecated, use 'quad' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.quad
 
     @property
     def crs(self):

--- a/ocsmesh/ops/combine_geom.py
+++ b/ocsmesh/ops/combine_geom.py
@@ -125,10 +125,10 @@ class GeomCombine:
                 _logger.info("Reprojecting base mesh...")
                 transformer = Transformer.from_crs(
                     base_crs, self._calc_crs, always_xy=True)
-                xy = base_mesh.coord
+                xy = base_mesh.coords
                 xy = np.vstack(
                     transformer.transform(xy[:, 0], xy[:, 1])).T
-                base_mesh.coord[:] = xy
+                base_mesh.coords[:] = xy
 
             _logger.info("Done")
 

--- a/tests/api/test_mesh.py
+++ b/tests/api/test_mesh.py
@@ -362,7 +362,7 @@ class RasterInterpolation(unittest.TestCase):
         rast = Raster(self.rast)
 
         self.mesh1.interpolate(rast)
-        self.assertTrue(np.isclose(self.mesh1.value, 1).all())
+        self.assertTrue(np.isclose(self.mesh1.values, 1).all())
 
         # TODO: Improve the assertion!
         with self.assertRaises(Exception):
@@ -373,10 +373,10 @@ class RasterInterpolation(unittest.TestCase):
         rast = Raster(self.rast)
 
         self.mesh1.interpolate(rast)
-        self.assertTrue(np.isclose(self.mesh1.value, 1).all())
+        self.assertTrue(np.isclose(self.mesh1.values, 1).all())
 
         self.mesh1.interpolate(rast, band=2)
-        self.assertTrue(np.isclose(self.mesh1.value, 2).all())
+        self.assertTrue(np.isclose(self.mesh1.values, 2).all())
 
 
     # TODO Add more interpolation tests


### PR DESCRIPTION
## Summary

This PR standardizes mesh attribute names across the codebase.
```coords, tria, quad, values``` are now the canonical API on all mesh classes, which fixes AttributeError issues when passing EuclideanMesh2D objects to utility functions.

Resolves #226 


## Changes

* **base.py** — `coords` is now the main property; `coord` is kept as a deprecated alias.
* **mesh.py** — `tria`, `quad`, and `values` replace `triangles`, `quads`, and `value`. Old names remain as deprecated aliases. Helpers updated.
* **collector.py** — Switched to `tria`, `coords`, `values`.
* **combine_geom.py** — Switched to `coords` in CRS reprojection.
* **test_mesh.py** — Updated `.value` to `.values`.


## Testing & Results

```bash
python -m pytest tests/ -v
# result: 175 passed, 8 skipped

#verify deprecated names warn and new names are silent with simple assertions
python -c "
import warnings, numpy as np
from ocsmesh.internal import MeshData
from ocsmesh.mesh.mesh import EuclideanMesh2D

md = MeshData(coords=np.array([[0,0],[1,0],[0.5,1.0]]), tria=np.array([[0,1,2]]))
m = EuclideanMesh2D(md)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    _ = m.coord; _ = m.triangles; _ = m.quads; _ = m.value
    assert len(w) == 4 and all(issubclass(x.category, DeprecationWarning) for x in w)
    print('PASS: all 4 old names warn correctly')

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    _ = m.coords; _ = m.tria; _ = m.quad; _ = m.values
    assert len(w) == 0
    print('PASS: new canonical names produce no warnings')
"
```
*Note**
I investigated the 8 skipped tests. They are pre-existing, intentional skips unrelated to our changes ,all 8 are conditionally skipped because I am running the test suite on **Windows**.

- **`test_avg_filter_nomask`**
- **`test_avg_filter_masked_nanfill`**
- **`test_avg_filter_masked_nonnanfill`**
- **`test_add_patch`**
- **`test_hfunraster_initial_value_logic`**
- **`test_execution_mode_property`**
- **`test_work_dir_cleanup`**
- **`test_serial_vs_parallel_equivalence`**