### PR TITLE
Add Workflow dispatch for workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,13 @@ on:
   release:
     types:
       - published
+    workflow_dispatch:
+      inputs:
+        deploy_docs:
+          description: 'Deploy documentation to GitHub Pages?'
+          required: true
+          type: boolean
+          default: false
 
 
 jobs:
@@ -48,7 +55,7 @@ jobs:
     name: deploy to GitHub Pages
     runs-on: ubuntu-latest
     needs: [ create-documentation ]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.deploy_docs == true)
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,13 +5,13 @@ on:
   release:
     types:
       - published
-    workflow_dispatch:
-      inputs:
-        deploy_docs:
-          description: 'Deploy documentation to GitHub Pages?'
-          required: true
-          type: boolean
-          default: false
+  workflow_dispatch:
+    inputs:
+      deploy_docs:
+        description: 'Deploy documentation to GitHub Pages?'
+        required: true
+        type: boolean
+        default: false
 
 
 jobs:

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -17,6 +17,7 @@ on:
       - 'pyproject.toml'
       - 'setup.py'
       - 'setup.cfg'
+  workflow_dispatch:
 
 jobs:
   basic-functional-tests:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,6 +17,7 @@ on:
       - 'pyproject.toml'
       - 'setup.py'
       - 'setup.cfg'
+  workflow_dispatch:
 
 jobs:
   format-check:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_pypi:
-        description: 'Publish package to PyPI?'
+        description: 'Publish package to PyPI ? *Note this workflow only runs on tags, so manual runs must be tag-based.*'
         required: true
         type: boolean
         default: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      publish_pypi:
+        description: 'Publish package to PyPI?'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build_packages:
@@ -37,7 +43,7 @@ jobs:
           name: build
           path: ./dist
   upload_pypi:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_pypi == true)
     name: publish to PyPI
     needs: [ build_packages ]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
           name: build
           path: ./dist
   upload_pypi:
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'    name: publish to PyPI
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    name: publish to PyPI
     needs: [ build_packages ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,7 @@ jobs:
           name: build
           path: ./dist
   upload_pypi:
-    if: github.event_name == 'release'
-    name: publish to PyPI
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'    name: publish to PyPI
     needs: [ build_packages ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,24 @@ on:
         default: false
 
 jobs:
+  precheck_tag:
+    name: precheck tag-only run
+    runs-on: ubuntu-latest
+    steps:
+      # Explicit tag-only guard for manual runs; avoids silent skip or unintended branch builds.
+      - name: assert tag-only run
+        shell: bash
+        run: |
+          echo "Note: this workflow can only run on tags."
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "::error::This workflow only runs on tags. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+          echo "Tag detected: ${GITHUB_REF#refs/tags/}"
   build_packages:
     name: build wheel & source distribtions
     runs-on: ${{ matrix.os }}
+    needs: [ precheck_tag ]
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -45,7 +60,7 @@ jobs:
   upload_pypi:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_pypi == true)
     name: publish to PyPI
-    needs: [ build_packages ]
+    needs: [ precheck_tag, build_packages ]
     runs-on: ubuntu-latest
     steps:
       - name: retrieve wheel(s) and source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       publish_pypi:
-        description: 'Publish package to PyPI ? *Note this workflow only runs on tags, so manual runs must be tag-based.*'
+        description: 'Publish package to PyPI? Note: publishing only runs on tags; build can run on branches for verification.'
         required: true
         type: boolean
         default: false
 
 jobs:
-  precheck_tag:
-    name: precheck tag-only run
-    runs-on: ubuntu-latest
-    steps:
-      # Explicit tag-only guard for manual runs; avoids silent skip or unintended branch builds.
-      - name: assert tag-only run
-        shell: bash
-        run: |
-          echo "Note: this workflow can only run on tags."
-          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-            echo "::error::This workflow only runs on tags. Current ref: ${GITHUB_REF}"
-            exit 1
-          fi
-          echo "Tag detected: ${GITHUB_REF#refs/tags/}"
   build_packages:
     name: build wheel & source distribtions
     runs-on: ${{ matrix.os }}
-    needs: [ precheck_tag ]
     strategy:
       matrix:
         os: [ ubuntu-latest ]
@@ -60,9 +45,19 @@ jobs:
   upload_pypi:
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish_pypi == true)
     name: publish to PyPI
-    needs: [ precheck_tag, build_packages ]
+    needs: [ build_packages ]
     runs-on: ubuntu-latest
     steps:
+      # Explicit tag-only guard for publish; gives a clear failure on branch runs.
+      - name: assert tag-only run
+        shell: bash
+        run: |
+          echo "Note: publishing only runs on tags."
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "::error::Publishing is tag-only. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+          echo "Tag detected: ${GITHUB_REF#refs/tags/}"
       - name: retrieve wheel(s) and source
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
   build_packages:


### PR DESCRIPTION
## Summary
This PR adds the option of Workflow dispatch for workflows to manually trigger workflows when needed

## Changes
After merging to main when visiting github actions page the option to trigger workflows manually will be available + for the "2 stages" (PyPi and documentation workflows) -> the option to enable/disable the second stage is presented.

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/b0ee85e8-3ff9-445b-b030-9ab86a7e43ed" />
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/a1056ae5-0d5f-4677-ba68-cdbce7e00255" />

## Note
Running the workflow dispatch must be on a branch or a tag that has this PR merged -> which means it won't be avaialbe to run on the current v2.1.1 tag, however it can run on main branch after merging or any new tags.

## Update
PR updated to run release workflow (Publish to PyPi Step)  on tags only not branches to avoid naming confusion.
