### PR TITLE
Fix Pylint workflow issue of new numpy versions (finfo max)

### DIFF
--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -78,7 +78,7 @@ class HfunInputRaster:
                     obj.modifying_raster(use_src_meta=False, **meta))
             for window in windows:
                 values = src.read(window=window).astype(np.float32)
-                values[:] = np.finfo(np.float32).max
+                values[:] = getattr(np.finfo(np.float32), 'max')
                 dst.write(values, window=window)
 
         obj.__dict__['raster'] = raster


### PR DESCRIPTION
## Summary
This PR fixes a Pylint `E1101` false positive in `ocsmesh/hfun/raster.py` caused by a known incompatibility between Pylint and NumPy 2.4.0+.

## Changes

**File:** `ocsmesh/hfun/raster.py:81`

```python
# Before
values[:] = np.finfo(np.float32).max

# After (fix)
values[:] = getattr(np.finfo(np.float32), 'max')
```

## Why

Pylint 2.4.3 raises the following on the original line (as happened in #233 workflow) :

```
E1101: Instance of 'finfo' has no 'max' member (no-member)
```

This is a **confirmed false positive**. It is tracked in the Pylint repo as [[issue #10806](https://github.com/pylint-dev/pylint/issues/10806)](https://github.com/pylint-dev/pylint/issues/10806) ->>> Pylint cannot find `finfo` attributes (such as `eps`, `max`) with NumPy 2.4.0+, producing `E1101: Instance of 'finfo' has no '...' member (no-member)`, despite them being valid runtime attributes.

Using `getattr(np.finfo(np.float32), 'max')` is functionally identical at runtime but bypasses the static member-existence check, eliminating the false positive without suppression comments.

## Note
There is **no runtime behavior change** — > both forms resolve to the same value.