### PR TITLE
feat: paralleize apply constraints()

### DIFF
--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -1644,10 +1644,11 @@ class HfunCollector(BaseHfun):
                 for _, c in self._constraint_info_coll
             )
             if has_func_constraint:
-                _logger.warning(
+                warnings.warn(
                     "TopoFuncConstraint contains a callable that cannot "
                     "be pickled for parallel execution. Falling back to "
-                    "serial for _apply_constraints()."
+                    "serial for _apply_constraints().",
+                    UserWarning
                 )
                 self._apply_constraints_serial()
             else:

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -541,18 +541,23 @@ class _ConstraintInfoCollector:
         yield from self._constraints_info
 
 
+    def get_constraints(self, hfun, in_idx, per_hfun=True):
+        is_raster = isinstance(hfun, HfunRaster)
+        constraint_list = []
+        for src_idx, constraint_defn in self:
+            if per_hfun and src_idx is not None and in_idx not in src_idx:
+                continue
+
+            if isinstance(constraint_defn, RASTER_CONSTR) and not is_raster:
+                continue
+
+            constraint_list.append(constraint_defn)
+        return constraint_list
+
+
     def apply(self, hfun_list, per_hfun=True):
         for in_idx, hfun in enumerate(hfun_list):
-            is_raster = isinstance(hfun, HfunRaster)
-            constraint_list = []
-            for src_idx, constraint_defn in self:
-                if per_hfun and src_idx is not None and in_idx not in src_idx:
-                    continue
-
-                if isinstance(constraint_defn, RASTER_CONSTR) and not is_raster:
-                    continue
-
-                constraint_list.append(constraint_defn)
+            constraint_list = self.get_constraints(hfun, in_idx, per_hfun)
 
             if constraint_list:
                 hfun.apply_constraints(constraint_list)
@@ -646,6 +651,50 @@ def _const_val_task_worker(task: dict):
     worker_hfun.save(output_path)
 
     # 5. The work is done. Return a simple result dictionary.
+    return {
+        'status': 'success',
+        'original_index': original_index,
+        'output_path': output_path
+    }
+
+
+def _constraints_task_worker(task: dict):
+    """
+    A self-contained worker for applying constraint objects to a single
+    HfunRaster.
+
+    This worker reconstructs the HfunRaster from file paths inside the
+    child process, applies pickleable constraint objects via
+    ``HfunRaster.apply_constraints()``, and saves the result to disk.
+    """
+
+    # 1. Unpack the simple, pickleable task description
+    original_index = task['original_index']
+    hfun_input_path = task['hfun_input_path']
+    topo_input_path = task['topo_input_path']
+    output_path = task['output_path']
+    global_hmin = task['global_hmin']
+    global_hmax = task['global_hmax']
+    constraint_list = task['constraint_list']
+
+    # 2. Create the necessary Raster and HfunRaster instances INSIDE the worker.
+    topo_raster = Raster(topo_input_path)
+    worker_hfun = HfunRaster(
+        raster=topo_raster,
+        hmin=global_hmin,
+        hmax=global_hmax,
+        verbosity=0,
+        initial_value=hfun_input_path
+    )
+
+    # 3. Apply the constraint objects using the existing HfunRaster method.
+    #    This handles windowed processing, hmin/hmax clamping, etc.
+    worker_hfun.apply_constraints(constraint_list)
+
+    # 4. Save the final state to the designated output path.
+    worker_hfun.save(output_path)
+
+    # 5. Return a simple result dictionary.
     return {
         'status': 'success',
         'original_index': original_index,
@@ -1564,12 +1613,13 @@ class HfunCollector(BaseHfun):
 
 
     def _apply_constraints(self) -> None:
-        """Internal: apply specified constraints.
+        """Internal: dispatch constraint application to serial or parallel.
 
-        Apply specified constraints for the exact algorithm.
-
-        Parameters
-        ----------
+        Dispatches to either ``_apply_constraints_serial`` or
+        ``_apply_constraints_parallel`` based on the current
+        ``execution_mode``.  When any ``TopoFuncConstraint`` is present
+        (which stores an unpickleable lambda), the parallel path falls
+        back to serial automatically with a logged warning.
 
         Returns
         -------
@@ -1577,14 +1627,159 @@ class HfunCollector(BaseHfun):
 
         See Also
         --------
+        _apply_constraints_serial :
+        _apply_constraints_parallel :
         _apply_constraints_fast :
         """
 
         if self._method == 'fast':
             raise NotImplementedError(
-                "This function does not suuport fast hfun method")
+                "This function does not support fast hfun method")
+
+        if self.execution_mode == 'parallel' and self._nprocs > 1:
+            # TopoFuncConstraint stores a lambda which cannot be pickled
+            # for multiprocessing.Pool — fall back to serial in that case.
+            has_func_constraint = any(
+                isinstance(c, TopoFuncConstraint)
+                for _, c in self._constraint_info_coll
+            )
+            if has_func_constraint:
+                _logger.warning(
+                    "TopoFuncConstraint contains a callable that cannot "
+                    "be pickled for parallel execution. Falling back to "
+                    "serial for _apply_constraints()."
+                )
+                self._apply_constraints_serial()
+            else:
+                _logger.info("Applying constraints using PARALLEL method.")
+                self._apply_constraints_parallel()
+        else:
+            _logger.info("Applying constraints using SERIAL method.")
+            self._apply_constraints_serial()
+
+
+    def _apply_constraints_serial(self) -> None:
+        """Internal: apply specified constraints serially.
+
+        Delegates to ``_ConstraintInfoCollector.apply()`` which iterates
+        over each hfun and applies matching constraints one-by-one.
+
+        Returns
+        -------
+        None
+        """
 
         self._constraint_info_coll.apply(self._hfun_list)
+
+
+    def _apply_constraints_parallel(self) -> None:
+        """Internal: apply specified constraints in parallel.
+
+        Uses the same 3-phase pattern as ``_apply_flow_limiters_parallel``:
+
+        1. **Preparation** — build one pickleable task dict per raster,
+           containing file paths + the list of applicable ``Constraint``
+           objects.
+        2. **Execution** — ``Pool.map()`` sends tasks to
+           ``_constraints_task_worker`` processes.
+        3. **Integration** — replace ``self._hfun_list`` entries with new
+           ``HfunRaster`` objects built from the worker output files.
+
+        Notes
+        -----
+        This method must **not** be called when any constraint is a
+        ``TopoFuncConstraint`` because its internal lambda is not
+        pickleable.  The dispatcher ``_apply_constraints()`` handles
+        this check.
+
+        Returns
+        -------
+        None
+        """
+
+        # Phase 1: PREPARATION
+        tasks = []
+        hfuns_to_process = {}
+
+        for in_idx, hfun in enumerate(self._hfun_list):
+            if not isinstance(hfun, HfunRaster):
+                continue
+
+            constraint_list = self._constraint_info_coll.get_constraints(
+                hfun, in_idx, per_hfun=True
+            )
+
+            if constraint_list:
+                hfuns_to_process[in_idx] = {
+                    'hfun': hfun,
+                    'constraints': constraint_list
+                }
+
+
+        # Same style as other functions 
+        # (Can be refactored to be a shared function that 
+        # accept needed parameters to make code cleaner)
+        # in another PR
+        for in_idx, data in hfuns_to_process.items():
+            hfun = data['hfun']
+            hfun_input_path = hfun.tmpfile
+            topo_input_path = hfun._raster.path  # pylint: disable=W0212
+
+            output_path = os.path.join(
+                self._work_dir, f"constraints_result_{in_idx}.tif")
+
+            task = {
+                'original_index': in_idx,
+                'hfun_input_path': hfun_input_path,
+                'topo_input_path': topo_input_path,
+                'output_path': output_path,
+                'global_hmin': hfun._hmin,   # pylint: disable=W0212
+                'global_hmax': hfun._hmax,   # pylint: disable=W0212
+                'constraint_list': data['constraints']
+            }
+            tasks.append(task)
+
+        if not tasks:
+            _logger.info("No constraint tasks to execute.")
+            return
+
+        # Phase 2: EXECUTION
+        _logger.info(
+            f"Start parallel execution for {len(tasks)} constraint tasks")
+        with Pool(processes=self._nprocs) as p:
+            results = p.map(_constraints_task_worker, tasks)
+        _logger.info("Parallel execution finished.")
+
+        # Same style as other functions 
+        # (Can be refactored to be a shared function that 
+        # accept needed parameters to make code cleaner)
+        # in another PR
+        # Phase 3: INTEGRATION
+        new_hfun_objects = {}
+        for result in results:
+            if result['status'] == 'error':
+                _logger.error(
+                    "Constraint worker %s failed: %s",
+                    result['original_index'],
+                    result['error'])
+                continue
+
+            idx = result['original_index']
+            output_path = result['output_path']
+            original_hfun = self._hfun_list[idx]
+
+            new_hfun_objects[idx] = HfunRaster(
+                raster=original_hfun.raster,
+                hmin=original_hfun.hmin,
+                hmax=original_hfun.hmax,
+                verbosity=original_hfun.verbosity,
+                initial_value=output_path
+            )
+
+        for idx, new_hfun in new_hfun_objects.items():
+            _logger.info(
+                f"Updating HfunCollector with constraint result at idx {idx}.")
+            self._hfun_list[idx] = new_hfun
 
 
     def _apply_contours(self, apply_to: Optional[SizeFuncList] = None) -> None:

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -165,6 +165,83 @@ class TestHfunCollectorExecution(unittest.TestCase):
         npt.assert_allclose(np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
 
 
+    @unittest.skipIf(IS_WINDOWS, 'Pickle tests not guaranteed stable on Windows due to I/O issues')
+    def test_serial_vs_parallel_constraints_equivalence(self):
+        """
+        Verify that _apply_constraints() produces numerically equivalent
+        results when run in serial vs parallel mode.
+
+        Uses TopoConstConstraint (pickleable) with a min and max constraint
+        to exercise both value_type paths.
+        """
+        nprocs = 2
+
+        # --- SERIAL EXECUTION ---
+        hfun_serial = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        # Default execution_mode is 'serial'
+        hfun_serial.add_topo_bound_constraint(
+            value=100, upper_bound=5, lower_bound=-5, value_type='min')
+        hfun_serial.add_topo_bound_constraint(
+            value=500, upper_bound=0, value_type='max')
+
+        print("\nRunning serial constraints execution...")
+        meshdata_serial = hfun_serial.meshdata()
+        values_serial = meshdata_serial.values
+        print("Serial constraints execution finished.")
+
+        # --- PARALLEL EXECUTION ---
+        hfun_parallel = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_parallel.execution_mode = 'parallel'
+        hfun_parallel.add_topo_bound_constraint(
+            value=100, upper_bound=5, lower_bound=-5, value_type='min')
+        hfun_parallel.add_topo_bound_constraint(
+            value=500, upper_bound=0, value_type='max')
+
+        print("Running parallel constraints execution...")
+        meshdata_parallel = hfun_parallel.meshdata()
+        values_parallel = meshdata_parallel.values
+        print("Parallel constraints execution finished.")
+
+        # --- COMPARISON ---
+        # Node count should be very close (meshing is non-deterministic)
+        self.assertAlmostEqual(
+            len(values_serial), len(values_parallel),
+            delta=len(values_serial) * 0.01)
+
+        # Statistical properties must be nearly identical
+        npt.assert_allclose(
+            np.min(values_serial), np.min(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.max(values_serial), np.max(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
+
+
+    @unittest.skipIf(IS_WINDOWS, 'Pickle tests not guaranteed stable on Windows due to I/O issues')
+    def test_parallel_falls_back_for_func_constraint(self):
+        """
+        Verify that when a TopoFuncConstraint (which stores a lambda)
+        is present, parallel mode gracefully falls back to serial
+        without raising a pickling error.
+        """
+        hfun = Hfun(self.raster_list, nprocs=2, hmin=10, hmax=1000)
+        hfun.execution_mode = 'parallel'
+
+        # TopoFuncConstraint uses a lambda — not pickleable by default.
+        # The dispatcher should detect this and fall back to serial.
+        hfun.add_topo_func_constraint(
+            func=lambda i: abs(i) / 2.0,
+            upper_bound=-10,
+            value_type='min',
+        )
+
+        # Should NOT raise PicklingError — falls back to serial
+        meshdata = hfun.meshdata()
+        self.assertIsNotNone(meshdata)
+        self.assertTrue(len(meshdata.values) > 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -237,8 +237,10 @@ class TestHfunCollectorExecution(unittest.TestCase):
             value_type='min',
         )
 
-        # Should NOT raise PicklingError — falls back to serial
-        meshdata = hfun.meshdata()
+        # Should NOT raise PicklingError — falls back to serial and emits a warning
+        with self.assertWarns(UserWarning):
+            meshdata = hfun.meshdata()
+        
         self.assertIsNotNone(meshdata)
         self.assertTrue(len(meshdata.values) > 0)
 

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -245,5 +245,57 @@ class TestHfunCollectorExecution(unittest.TestCase):
         self.assertTrue(len(meshdata.values) > 0)
 
 
+    def test_mixed_raster_mesh_constraint_filtering(self):
+        """
+        Verify that constraints are correctly filtered when applied to a mix of
+        rasters and meshes, using selective source indices.
+        """
+        from ocsmesh.hfun.collector import _ConstraintInfoCollector
+        from ocsmesh.features.constraint import TopoConstConstraint
+        from unittest.mock import MagicMock
+        from ocsmesh.hfun.raster import HfunRaster
+        from ocsmesh.hfun.mesh import HfunMesh
+
+        coll = _ConstraintInfoCollector()
+        
+        # Add constraint 1: applies to indices 1, 2, 3
+        c1 = TopoConstConstraint(10, value_type='min')
+        coll.add([1, 2, 3], c1)
+        
+        # Add constraint 2: applies to indices 1, 7, 8
+        c2 = TopoConstConstraint(20, value_type='min')
+        coll.add([1, 7, 8], c2)
+        
+        # Add constraint 3: applies to all (no source_index)
+        c3 = TopoConstConstraint(30, value_type='min')
+        coll.add(None, c3)
+        
+        mock_raster = MagicMock(spec=HfunRaster)
+        mock_mesh = MagicMock(spec=HfunMesh)
+        
+        # Test all indices based on the mixed scenario:
+        # 1: raster, 2: raster, 3: raster
+        # 4: mesh, 5: mesh, 6: mesh
+        # 7: raster, 8: raster, 9: raster
+        
+        # Index 1 (Raster) -> Expected: c1, c2, c3
+        self.assertEqual(coll.get_constraints(mock_raster, 1), [c1, c2, c3])
+        
+        # Index 2 & 3 (Raster) -> Expected: c1, c3
+        for idx in [2 , 3]:
+            self.assertEqual(coll.get_constraints(mock_raster, idx), [c1, c3])
+                
+        # Index 4 & 5 & 6 (Mesh) -> Expected: []
+        for idx in [4 , 5 , 6]:
+            self.assertEqual(coll.get_constraints(mock_mesh, idx), [])
+        
+        # Index 7 & 8 (Raster) -> Expected: c2, c3
+        for idx in [7 , 8]:
+            self.assertEqual(coll.get_constraints(mock_raster, idx), [c2, c3])
+        
+        # Index 9 (Raster) -> Expected: c3
+        self.assertEqual(coll.get_constraints(mock_raster, 9), [c3])
+        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary
This PR parallelizes topography constraint application in `HfunCollector` using the 3-phase multiprocessing worker pattern

### Changes
#### New Features
* **Parallel Constraint Coordinator (`_apply_constraints_parallel`)**: Coordinates task preparation, process pool mapping (`Pool.map`), and result integration.
* **Top-Level Task Worker (`_constraints_task_worker`)**: A standalone function that unpickles tasks, constructs temporary raster instances, applies the constraints, and writes the output back to temporary files.
* **Fallback Dispatcher (`_apply_constraints`)**: Intercepts constraint execution to check for unpickleable `TopoFuncConstraint` objects, falling back to serial mode when detected to prevent runtime serialization failures.

#### Refactoring
* **Deduplicated Constraint Filtering**: Extracted the filtering and classification logic from `_ConstraintInfoCollector.apply` into a new, reusable `get_constraints(hfun, in_idx, per_hfun)` method. This allows both the serial `.apply()` method and the parallel coordinator to share the exact same filter rules without duplicated code blocks.

#### Tests
* Added `test_serial_vs_parallel_constraints_equivalence` to verify that serial and parallel paths produce identical size function outputs (within `rtol=1e-5`).
* Added `test_parallel_falls_back_for_func_constraint` to verify that registering a `TopoFuncConstraint` (lambda function) triggers a warning and successfully falls back to serial execution.

#### Notes
* Why the TopoFuncConstraint Check is Safe & Necessary: TopoFuncConstraint allows users to constrain mesh size using a custom mathematical formula (e.g. add_topo_func_constraint(func=lambda x: x / 2.0)). Because Python's default pickle module cannot serialize anonymous lambda functions for transmission to worker processes, passing a TopoFuncConstraint directly to Pool.map would result in a PicklingError.
```  Threw `AttributeError: Can't get local object 'TestHfunCollectorExecution.test_parallel_falls_back_for_func_constraint.<locals>.<lambda>'`. ```

* No Impact on Runs: The library does not register any lambda-based constraints internally. Therefore, the dispatcher check will evaluate to False in almost all normal use cases, allowing constraint execution to run in parallel by default.