### PR TITLE
feat: parallelize apply_patch & apply_channels

### DIFF
--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -1877,30 +1877,31 @@ class HfunCollector(BaseHfun):
             # Channels are ONLY extracted from raster sources
             self._channels_coll.calculate(raster_hfun_list, temp_path)
             counter = 0
-            for hfun in apply_to:
-                for gdf in self._channels_coll:
-                    for row in gdf.itertuples():
-                        _logger.debug(row)
-                        shape = row.geometry
-                        if isinstance(shape, GeometryCollection):
-                            continue
-                        # NOTE: CRS check is done AFTER
-                        # GeometryCollection check because
-                        # gdf.to_crs results in an error in case
-                        # of empty GeometryCollection
-                        if not gdf.crs.equals(hfun.crs):
-                            _logger.info("Reprojecting feature...")
-                            transformer = Transformer.from_crs(
-                                gdf.crs, hfun.crs, always_xy=True)
-                            shape = ops.transform(
-                                    transformer.transform, shape)
-                        counter = counter + 1
-                        hfun.add_patch(**{
-                            'multipolygon': shape,
-                            'expansion_rate': row.expansion_rate,
-                            'target_size': row.target_size,
-                            'nprocs': self._nprocs
-                        })
+            with Pool(processes=self._nprocs) as p:
+                for hfun in apply_to:
+                    for gdf in self._channels_coll:
+                        for row in gdf.itertuples():
+                            _logger.debug(row)
+                            shape = row.geometry
+                            if isinstance(shape, GeometryCollection):
+                                continue
+                            # NOTE: CRS check is done AFTER
+                            # GeometryCollection check because
+                            # gdf.to_crs results in an error in case
+                            # of empty GeometryCollection
+                            if not gdf.crs.equals(hfun.crs):
+                                _logger.info("Reprojecting feature...")
+                                transformer = Transformer.from_crs(
+                                    gdf.crs, hfun.crs, always_xy=True)
+                                shape = ops.transform(
+                                        transformer.transform, shape)
+                            counter = counter + 1
+                            hfun.add_patch(**{
+                                'multipolygon': shape,
+                                'expansion_rate': row.expansion_rate,
+                                'target_size': row.target_size,
+                                'pool': p
+                            })
 
 
     @property
@@ -2281,18 +2282,18 @@ class HfunCollector(BaseHfun):
                 mesh_hfun_list.insert(0, self._base_mesh)
             apply_to = [*mesh_hfun_list, *raster_hfun_list]
 
-        # TODO: Parallelize
-        for hfun in apply_to:
-            for patch_defn, size_info in self._refine_patch_info_coll:
-                shape, crs = patch_defn.get_multipolygon()
-                if hfun.crs != crs:
-                    transformer = Transformer.from_crs(
-                        crs, hfun.crs, always_xy=True)
-                    shape = ops.transform(
-                            transformer.transform, shape)
+        with Pool(processes=self._nprocs) as p:
+            for hfun in apply_to:
+                for patch_defn, size_info in self._refine_patch_info_coll:
+                    shape, crs = patch_defn.get_multipolygon()
+                    if hfun.crs != crs:
+                        transformer = Transformer.from_crs(
+                            crs, hfun.crs, always_xy=True)
+                        shape = ops.transform(
+                                transformer.transform, shape)
 
-                hfun.add_patch(
-                        shape, nprocs=self._nprocs, **size_info)
+                    hfun.add_patch(
+                            shape, pool=p, **size_info)
 
 
     def _apply_linefeatures(self, apply_to: Optional[SizeFuncList] = None) -> None:

--- a/ocsmesh/hfun/mesh.py
+++ b/ocsmesh/hfun/mesh.py
@@ -8,7 +8,8 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Union, Optional, Iterable, Literal
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count
+from multiprocessing.pool import Pool
 from time import time
 
 from matplotlib.transforms import Bbox
@@ -213,12 +214,14 @@ class HfunMesh(BaseHfun):
 
 
     @apply_constraints_wrap
+    @utils.add_pool_args
     def add_patch(
             self,
             multipolygon: Union[MultiPolygon, Polygon],
             expansion_rate: Optional[float] = None,
             target_size: Optional[float] = None,
-            nprocs: Optional[int] = None
+            *, # kwarg-only comes after this
+            pool: Pool,
             ) -> None:
         """Add refinement as a region of fixed size with an optional rate
 
@@ -237,9 +240,9 @@ class HfunMesh(BaseHfun):
         target_size : float or None, default=None
             Fixed target size of mesh to use for refinement in
             `multipolygon`
-        nprocs : int or None, default=None
-            Number of processors to use in parallel sections of the
-            algorithm
+        pool : Pool
+            Pre-created and initialized process pool to be used for
+            parallel sections of the algorithm.
 
         Returns
         -------
@@ -251,8 +254,6 @@ class HfunMesh(BaseHfun):
             Add refinement for specified line string
         """
 
-        # TODO: Add pool input support like add_feature for performance
-
         # pylint: disable=R0801
         # TODO: Support other shapes - call buffer(1) on non polygons(?)
         if not isinstance(multipolygon, (Polygon, MultiPolygon)):
@@ -263,10 +264,7 @@ class HfunMesh(BaseHfun):
         if isinstance(multipolygon, Polygon):
             multipolygon = MultiPolygon([multipolygon])
 
-        # Check nprocs
-        nprocs = -1 if nprocs is None else nprocs
-        nprocs = cpu_count() if nprocs == -1 else nprocs
-        _logger.debug(f'Using nprocs={nprocs}')
+
 
 
         # check target size
@@ -290,7 +288,7 @@ class HfunMesh(BaseHfun):
                 feature=features,
                 expansion_rate=expansion_rate,
                 target_size=target_size,
-                nprocs=nprocs)
+                pool=pool)
 
         mesh_values = self.mesh.meshdata.values
         values = mesh_values.copy()

--- a/ocsmesh/hfun/mesh.py
+++ b/ocsmesh/hfun/mesh.py
@@ -8,7 +8,6 @@ import warnings
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Union, Optional, Iterable, Literal
-from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
 from time import time
 

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -1011,13 +1011,15 @@ class HfunRaster(BaseHfun, Raster):
                 nprocs=nprocs)
 
     @apply_constraints_wrap
+    @utils.add_pool_args
     def add_channel(
             self,
             level: float = 0,
             width: float = 1000,
             target_size: float = 200,
             expansion_rate: Optional[float] = None,
-            nprocs: Optional[int] = None,
+            *,
+            pool: Pool,
             tolerance: Optional[float] = None
             ) -> None:
         """Add refinement for auto detected channels
@@ -1039,9 +1041,9 @@ class HfunRaster(BaseHfun, Raster):
         expansion_rate : float or None, default=None
             Rate to use for expanding refinement with distance away
             from the detected channels.
-        nprocs : int or None, default=None
-            Number of processes to use for parallel sections of the
-            workflow.
+        pool : Pool
+            Pre-created and initialized process pool to be used for
+            parallel sections of the workflow.
         tolerance: float or None, default=None
             Tolerance to use for simplifying the polygon extracted
             from DEM data. If `None` don't simplify.
@@ -1073,9 +1075,8 @@ class HfunRaster(BaseHfun, Raster):
         if channels is None:
             return
 
-        # pylint: disable=E1123, E1125
         self.add_patch(
-            channels, expansion_rate, target_size, nprocs=nprocs)
+            channels, expansion_rate, target_size, pool=pool)
 
 
 

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -5,7 +5,6 @@ import shutil
 import gc
 import logging
 import os
-from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
 import operator
 import pathlib
@@ -1074,6 +1073,7 @@ class HfunRaster(BaseHfun, Raster):
         if channels is None:
             return
 
+        # pylint: disable=E1123, E1125
         self.add_patch(
             channels, expansion_rate, target_size, nprocs=nprocs)
 

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -5,7 +5,8 @@ import shutil
 import gc
 import logging
 import os
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count
+from multiprocessing.pool import Pool
 import operator
 import pathlib
 import tempfile
@@ -800,12 +801,14 @@ class HfunRaster(BaseHfun, Raster):
 
 
     @apply_constraints_wrap
+    @utils.add_pool_args
     def add_patch(
             self,
             multipolygon: Union[MultiPolygon, Polygon],
             expansion_rate: Optional[float] = None,
             target_size: Optional[float] = None,
-            nprocs: Optional[int] = None
+            *, # kwarg-only comes after this
+            pool: Pool,
             ) -> None:
         """Add refinement as a region of fixed size with an optional rate
 
@@ -824,9 +827,9 @@ class HfunRaster(BaseHfun, Raster):
         target_size : float or None, default=None
             Fixed target size of mesh to use for refinement in
             `multipolygon`
-        nprocs : int or None, default=None
-            Number of processors to use in parallel sections of the
-            algorithm
+        pool : Pool
+            Pre-created and initialized process pool to be used for
+            parallel sections of the algorithm.
 
         Returns
         -------
@@ -846,8 +849,6 @@ class HfunRaster(BaseHfun, Raster):
             Add refinement with fixed value
         """
 
-        # TODO: Add pool input support like add_feature for performance
-
         # pylint: disable=R0801
         # TODO: Support other shapes - call buffer(1) on non polygons(?)
         if not isinstance(multipolygon, (Polygon, MultiPolygon)):
@@ -858,10 +859,7 @@ class HfunRaster(BaseHfun, Raster):
         if isinstance(multipolygon, Polygon):
             multipolygon = MultiPolygon([multipolygon])
 
-        # Check nprocs
-        nprocs = -1 if nprocs is None else nprocs
-        nprocs = cpu_count() if nprocs == -1 else nprocs
-        _logger.debug(f'Using nprocs={nprocs}')
+
 
 
         # check target size
@@ -885,7 +883,7 @@ class HfunRaster(BaseHfun, Raster):
                 feature=features,
                 expansion_rate=expansion_rate,
                 target_size=target_size,
-                nprocs=nprocs)
+                pool=pool)
 
         with self.modifying_raster(driver='GTiff') as dst:
             iter_windows = list(self.iter_windows())
@@ -1077,7 +1075,7 @@ class HfunRaster(BaseHfun, Raster):
             return
 
         self.add_patch(
-            channels, expansion_rate, target_size, nprocs)
+            channels, expansion_rate, target_size, nprocs=nprocs)
 
 
 

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -211,6 +211,12 @@ class TestHfunCollectorExecution(unittest.TestCase):
 
         # --- COMPARISON ---
         # Node count should be very close (meshing is non-deterministic)
+
+        # TODO: In the future, we should consider using proper
+        # statistical tests 
+        # like F-test or two-sampled t-test to compare
+        # the two results instead of these basic checks.
+
         self.assertAlmostEqual(
             len(values_serial), len(values_parallel),
             delta=len(values_serial) * 0.01)
@@ -330,6 +336,10 @@ class TestHfunCollectorExecution(unittest.TestCase):
         values_parallel = meshdata_parallel.values
 
         # --- COMPARISON ---
+        # TODO: In the future, we should consider using proper
+        # statistical tests 
+        # like F-test or two-sampled t-test to compare
+        # the two results instead of these basic checks.
         self.assertAlmostEqual(
             len(values_serial), len(values_parallel),
             delta=len(values_serial) * 0.01)
@@ -376,6 +386,10 @@ class TestHfunCollectorExecution(unittest.TestCase):
         values_parallel = meshdata_parallel.values
 
         # --- COMPARISON ---
+        # TODO: In the future, we should consider using proper
+        # statistical tests 
+        # like F-test or two-sampled t-test to compare
+        # the two results instead of these basic checks.
         self.assertAlmostEqual(
             len(values_serial), len(values_parallel),
             delta=len(values_serial) * 0.01)
@@ -417,6 +431,10 @@ class TestHfunCollectorExecution(unittest.TestCase):
         values_parallel = meshdata_parallel.values
 
         # --- COMPARISON ---
+        # TODO: In the future, we should consider using proper
+        # statistical tests 
+        # like F-test or two-sampled t-test to compare
+        # the two results instead of these basic checks.
         self.assertAlmostEqual(
             len(values_serial), len(values_parallel),
             delta=len(values_serial) * 0.01)
@@ -444,6 +462,7 @@ class TestHfunCollectorExecution(unittest.TestCase):
             multipolygon=bx, target_size=200, nprocs=2)
 
         # Verify values were actually modified
+        # TODO: The test is too loose,would be better to comeup with better one.
         values = hfun.get_values()
         self.assertTrue(np.any(values <= 200),
             "Patch target_size was not applied to raster values")
@@ -464,6 +483,9 @@ class TestHfunCollectorExecution(unittest.TestCase):
             multipolygon=bx, target_size=200,
             expansion_rate=0.1, nprocs=2)
 
+        # TODO: The test criteria does not really 
+        # check what was applied. If we want to check the expansion here,
+        # we need to make the fit tighter.
         values = hfun.get_values()
         self.assertTrue(np.any(values <= 200),
             "Patch target_size was not applied to raster values")
@@ -498,6 +520,11 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun.add_channel(
             level=0, width=200, target_size=100, nprocs=2)
 
+        # TODO: Come up with a better check. 
+        # Use ocsmesh.utils.get_polygon_channels(polygon, width)
+        # to get the channel polygon, select nodes in
+        # the polygon, and get the values of the selected 
+        # nodes to make sure their mean is close to the target size.
         values = hfun.get_values()
         self.assertIsNotNone(values)
 

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import gc
 import os
+from multiprocessing.pool import Pool
 from pathlib import Path
 import numpy as np
 import numpy.testing as npt
@@ -461,17 +462,34 @@ class TestHfunCollectorExecution(unittest.TestCase):
             "Patch target_size was not applied to raster values")
 
     @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
-    def test_add_channel_backward_compat_nprocs(self):
+    def test_add_channel_with_pool(self):
         """
-        Verify that calling HfunRaster.add_channel() with the
-        nprocs= kwarg still works. add_channel was not refactored
-        with @add_pool_args, so nprocs is passed directly.
+        Verify that calling HfunRaster.add_channel() with an explicit
+        pool works and exercises the pool-forwarding path used by the
+        add_pool_args decorator.
         """
         rast = Raster(self.dem1_path)
         hfun = HfunRaster(rast, hmin=10, hmax=1000)
 
-        # add_channel still accepts nprocs= directly
-        # This should not raise any error
+        with Pool(processes=2) as pool:
+            hfun.add_channel(
+                level=0, width=200, target_size=100, pool=pool)
+
+        values = hfun.get_values()
+        self.assertIsNotNone(values)
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_add_channel_backward_compat_nprocs(self):
+        """
+        Verify that calling HfunRaster.add_channel() with the old
+        nprocs= kwarg still works via @add_pool_args decorator.
+        This keeps compatibility with existing callers.
+        """
+        rast = Raster(self.dem1_path)
+        hfun = HfunRaster(rast, hmin=10, hmax=1000)
+
+        # Old API: nprocs= should be translated to pool= by decorator.
+        # pylint: disable=unexpected-keyword-arg,missing-kwoa
         hfun.add_channel(
             level=0, width=200, target_size=100, nprocs=2)
 

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import numpy as np
 import numpy.testing as npt
+from shapely import geometry
 
 from ocsmesh import Hfun, Raster
 from ocsmesh.hfun.raster import HfunRaster
@@ -296,6 +297,208 @@ class TestHfunCollectorExecution(unittest.TestCase):
         # Index 9 (Raster) -> Expected: c3
         self.assertEqual(coll.get_constraints(mock_raster, 9), [c3])
         
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_serial_vs_parallel_patch_equivalence(self):
+        """
+        Verify that add_patch() without expansion_rate produces
+        equivalent results in serial vs parallel modes.
+
+        Exercises: _apply_patch() -> hfun.add_patch(pool=p)
+        """
+        nprocs = 2
+        bx = geometry.box(0.2, 0.2, 0.8, 0.8)
+
+        # --- SERIAL ---
+        hfun_serial = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_serial.add_patch(shape=bx, target_size=50)
+
+        print("\nRunning serial patch execution...")
+        meshdata_serial = hfun_serial.meshdata()
+        values_serial = meshdata_serial.values
+        print("Serial patch execution finished.")
+
+        # --- PARALLEL ---
+        hfun_parallel = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_parallel.execution_mode = 'parallel'
+        hfun_parallel.add_patch(shape=bx, target_size=50)
+
+        print("Running parallel patch execution...")
+        meshdata_parallel = hfun_parallel.meshdata()
+        values_parallel = meshdata_parallel.values
+        print("Parallel patch execution finished.")
+
+        # --- COMPARISON ---
+        self.assertAlmostEqual(
+            len(values_serial), len(values_parallel),
+            delta=len(values_serial) * 0.01)
+        npt.assert_allclose(
+            np.min(values_serial), np.min(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.max(values_serial), np.max(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
+
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_serial_vs_parallel_patch_with_expansion_equivalence(self):
+        """
+        Verify that add_patch() WITH expansion_rate produces
+        equivalent results in serial vs parallel modes.
+
+        This is the critical path: add_patch(pool=p) internally
+        calls add_feature(pool=pool), exercising the shared-pool
+        forwarding chain.
+
+        Exercises: _apply_patch() -> hfun.add_patch(pool=p)
+                                       -> hfun.add_feature(pool=pool)
+        """
+        nprocs = 2
+        bx = geometry.box(0.2, 0.2, 0.8, 0.8)
+
+        # --- SERIAL ---
+        hfun_serial = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_serial.add_patch(
+            shape=bx, target_size=200, expansion_rate=0.1)
+
+        print("\nRunning serial patch+expansion execution...")
+        meshdata_serial = hfun_serial.meshdata()
+        values_serial = meshdata_serial.values
+        print("Serial patch+expansion execution finished.")
+
+        # --- PARALLEL ---
+        hfun_parallel = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_parallel.execution_mode = 'parallel'
+        hfun_parallel.add_patch(
+            shape=bx, target_size=200, expansion_rate=0.1)
+
+        print("Running parallel patch+expansion execution...")
+        meshdata_parallel = hfun_parallel.meshdata()
+        values_parallel = meshdata_parallel.values
+        print("Parallel patch+expansion execution finished.")
+
+        # --- COMPARISON ---
+        self.assertAlmostEqual(
+            len(values_serial), len(values_parallel),
+            delta=len(values_serial) * 0.01)
+        npt.assert_allclose(
+            np.min(values_serial), np.min(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.max(values_serial), np.max(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
+
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_serial_vs_parallel_channel_equivalence(self):
+        """
+        Verify that add_channel() produces equivalent results in
+        serial vs parallel modes.
+
+        Exercises: _apply_channels() -> hfun.add_patch(pool=p)
+                                          -> hfun.add_feature(pool=pool)
+        """
+        nprocs = 2
+
+        # --- SERIAL ---
+        hfun_serial = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_serial.add_channel(
+            level=0, width=200, target_size=100, expansion_rate=0.1)
+
+        print("\nRunning serial channel execution...")
+        meshdata_serial = hfun_serial.meshdata()
+        values_serial = meshdata_serial.values
+        print("Serial channel execution finished.")
+
+        # --- PARALLEL ---
+        hfun_parallel = Hfun(
+            self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
+        hfun_parallel.execution_mode = 'parallel'
+        hfun_parallel.add_channel(
+            level=0, width=200, target_size=100, expansion_rate=0.1)
+
+        print("Running parallel channel execution...")
+        meshdata_parallel = hfun_parallel.meshdata()
+        values_parallel = meshdata_parallel.values
+        print("Parallel channel execution finished.")
+
+        # --- COMPARISON ---
+        self.assertAlmostEqual(
+            len(values_serial), len(values_parallel),
+            delta=len(values_serial) * 0.01)
+        npt.assert_allclose(
+            np.min(values_serial), np.min(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.max(values_serial), np.max(values_parallel), rtol=1e-5)
+        npt.assert_allclose(
+            np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
+
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_add_patch_backward_compat_nprocs(self):
+        """
+        Verify that calling HfunRaster.add_patch() with the old
+        nprocs= kwarg still works via @add_pool_args decorator
+        auto-spawn. This ensures external code using the old API
+        is not broken.
+        """
+        rast = Raster(self.dem1_path)
+        hfun = HfunRaster(rast, hmin=10, hmax=1000)
+        bx = geometry.box(0.2, 0.2, 0.8, 0.8)
+
+        # Old API: nprocs= should be translated to pool= by decorator
+        hfun.add_patch(
+            multipolygon=bx, target_size=200, nprocs=2)
+
+        # Verify values were actually modified
+        values = hfun.get_values()
+        self.assertTrue(np.any(values <= 200),
+            "Patch target_size was not applied to raster values")
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_add_patch_with_expansion_backward_compat_nprocs(self):
+        """
+        Verify that calling HfunRaster.add_patch() with expansion_rate
+        and the old nprocs= kwarg still works. This exercises the
+        decorator -> add_feature forwarding path via nprocs.
+        """
+        rast = Raster(self.dem1_path)
+        hfun = HfunRaster(rast, hmin=10, hmax=1000)
+        bx = geometry.box(0.2, 0.2, 0.8, 0.8)
+
+        # Old API with expansion_rate: nprocs= triggers decorator,
+        # which creates a pool and passes it to add_feature internally
+        hfun.add_patch(
+            multipolygon=bx, target_size=200,
+            expansion_rate=0.1, nprocs=2)
+
+        values = hfun.get_values()
+        self.assertTrue(np.any(values <= 200),
+            "Patch target_size was not applied to raster values")
+
+    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
+    def test_add_channel_backward_compat_nprocs(self):
+        """
+        Verify that calling HfunRaster.add_channel() with the
+        nprocs= kwarg still works. add_channel was not refactored
+        with @add_pool_args, so nprocs is passed directly.
+        """
+        rast = Raster(self.dem1_path)
+        hfun = HfunRaster(rast, hmin=10, hmax=1000)
+
+        # add_channel still accepts nprocs= directly
+        # This should not raise any error
+        hfun.add_channel(
+            level=0, width=200, target_size=100, nprocs=2)
+
+        values = hfun.get_values()
+        self.assertIsNotNone(values)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -302,7 +302,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
         self.assertEqual(coll.get_constraints(mock_raster, 9), [c3])
         
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_serial_vs_parallel_patch_equivalence(self):
         """
         Verify that add_patch() without expansion_rate produces
@@ -342,7 +341,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
             np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
 
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_serial_vs_parallel_patch_with_expansion_equivalence(self):
         """
         Verify that add_patch() WITH expansion_rate produces
@@ -389,7 +387,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
             np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
 
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_serial_vs_parallel_channel_equivalence(self):
         """
         Verify that add_channel() produces equivalent results in
@@ -431,7 +428,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
             np.mean(values_serial), np.mean(values_parallel), rtol=1e-5)
 
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_add_patch_backward_compat_nprocs(self):
         """
         Verify that calling HfunRaster.add_patch() with the old
@@ -452,7 +448,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
         self.assertTrue(np.any(values <= 200),
             "Patch target_size was not applied to raster values")
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_add_patch_with_expansion_backward_compat_nprocs(self):
         """
         Verify that calling HfunRaster.add_patch() with expansion_rate
@@ -473,7 +468,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
         self.assertTrue(np.any(values <= 200),
             "Patch target_size was not applied to raster values")
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_add_channel_with_pool(self):
         """
         Verify that calling HfunRaster.add_channel() with an explicit
@@ -490,7 +484,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
         values = hfun.get_values()
         self.assertIsNotNone(values)
 
-    @unittest.skipIf(IS_WINDOWS, 'Pool tests not guaranteed stable on Windows due to I/O issues')
     def test_add_channel_backward_compat_nprocs(self):
         """
         Verify that calling HfunRaster.add_channel() with the old

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -74,7 +74,6 @@ class TestHfunCollectorExecution(unittest.TestCase):
         npt.assert_allclose(loaded_values, initial_data)
         # Ensure it's not the default "blank" value
         self.assertNotEqual(loaded_values[0, 0], np.finfo(np.float32).max)
-        print("\nSUCCESS: HfunRaster correctly initializes from `initial_value`.")
 
 
     @unittest.skipIf(IS_WINDOWS, 'Pickle tests not guaranteed stable on Windows due to I/O issues')
@@ -134,10 +133,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_serial.add_subtidal_flow_limiter(hmin=50, lower_bound=-5, upper_bound=5)
         hfun_serial.add_constant_value(value=200, lower_bound=5, upper_bound=10)
         
-        print("\nRunning serial execution...")
         meshdata_serial = hfun_serial.meshdata()
         values_serial = meshdata_serial.values
-        print("Serial execution finished.")
 
         # --- PARALLEL EXECUTION ---
         hfun_parallel = Hfun(self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
@@ -147,10 +144,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_parallel.add_subtidal_flow_limiter(hmin=50, lower_bound=-5, upper_bound=5)
         hfun_parallel.add_constant_value(value=200, lower_bound=5, upper_bound=10)
 
-        print("Running parallel execution...")
         meshdata_parallel = hfun_parallel.meshdata()
         values_parallel = meshdata_parallel.values
-        print("Parallel execution finished.")
         
         # --- COMPARISON ---
         # NOTE: Due to minor floating point differences in meshing algorithms,
@@ -186,10 +181,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_serial.add_topo_bound_constraint(
             value=500, upper_bound=0, value_type='max')
 
-        print("\nRunning serial constraints execution...")
         meshdata_serial = hfun_serial.meshdata()
         values_serial = meshdata_serial.values
-        print("Serial constraints execution finished.")
 
         # --- PARALLEL EXECUTION ---
         hfun_parallel = Hfun(
@@ -200,10 +193,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_parallel.add_topo_bound_constraint(
             value=500, upper_bound=0, value_type='max')
 
-        print("Running parallel constraints execution...")
         meshdata_parallel = hfun_parallel.meshdata()
         values_parallel = meshdata_parallel.values
-        print("Parallel constraints execution finished.")
 
         # --- COMPARISON ---
         # Node count should be very close (meshing is non-deterministic)
@@ -314,10 +305,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
             self.raster_list, nprocs=nprocs, hmin=10, hmax=1000)
         hfun_serial.add_patch(shape=bx, target_size=50)
 
-        print("\nRunning serial patch execution...")
         meshdata_serial = hfun_serial.meshdata()
         values_serial = meshdata_serial.values
-        print("Serial patch execution finished.")
 
         # --- PARALLEL ---
         hfun_parallel = Hfun(
@@ -325,10 +314,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_parallel.execution_mode = 'parallel'
         hfun_parallel.add_patch(shape=bx, target_size=50)
 
-        print("Running parallel patch execution...")
         meshdata_parallel = hfun_parallel.meshdata()
         values_parallel = meshdata_parallel.values
-        print("Parallel patch execution finished.")
 
         # --- COMPARISON ---
         self.assertAlmostEqual(
@@ -364,10 +351,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_serial.add_patch(
             shape=bx, target_size=200, expansion_rate=0.1)
 
-        print("\nRunning serial patch+expansion execution...")
         meshdata_serial = hfun_serial.meshdata()
         values_serial = meshdata_serial.values
-        print("Serial patch+expansion execution finished.")
 
         # --- PARALLEL ---
         hfun_parallel = Hfun(
@@ -376,10 +361,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_parallel.add_patch(
             shape=bx, target_size=200, expansion_rate=0.1)
 
-        print("Running parallel patch+expansion execution...")
         meshdata_parallel = hfun_parallel.meshdata()
         values_parallel = meshdata_parallel.values
-        print("Parallel patch+expansion execution finished.")
 
         # --- COMPARISON ---
         self.assertAlmostEqual(
@@ -410,10 +393,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_serial.add_channel(
             level=0, width=200, target_size=100, expansion_rate=0.1)
 
-        print("\nRunning serial channel execution...")
         meshdata_serial = hfun_serial.meshdata()
         values_serial = meshdata_serial.values
-        print("Serial channel execution finished.")
 
         # --- PARALLEL ---
         hfun_parallel = Hfun(
@@ -422,10 +403,8 @@ class TestHfunCollectorExecution(unittest.TestCase):
         hfun_parallel.add_channel(
             level=0, width=200, target_size=100, expansion_rate=0.1)
 
-        print("Running parallel channel execution...")
         meshdata_parallel = hfun_parallel.meshdata()
         values_parallel = meshdata_parallel.values
-        print("Parallel channel execution finished.")
 
         # --- COMPARISON ---
         self.assertAlmostEqual(

--- a/tests/api/test_collector_pickle.py
+++ b/tests/api/test_collector_pickle.py
@@ -47,7 +47,19 @@ class TestHfunCollectorExecution(unittest.TestCase):
 
     def tearDown(self):
         """Remove the temporary directory and all its contents."""
-        shutil.rmtree(self.tdir)
+        # Fix for Windows: rasterio/GDAL keeps file handles open as long as
+        # Raster objects are in memory. Windows prevents deleting open files.
+        # We explicitly destroy the raster objects to release the file locks.
+        self.raster_list = None
+        gc.collect()
+        
+        try:
+            shutil.rmtree(self.tdir)
+        except PermissionError:
+            # Even after garbage collection, the Windows filesystem is sometimes
+            # too slow to release the lock before rmtree executes. Since this is 
+            # just a temporary test directory, it is safe to ignore.
+            pass
 
 
     @unittest.skipIf(IS_WINDOWS, 'Pickle tests not guaranteed stable on Windows due to I/O issues')


### PR DESCRIPTION
### Summary
This PR parallelizes _apply_patch() and _apply_channels() by introducing a shared-pool pattern -> a single Pool is created at the dispatch level and passed downward via pool=p, matching the existing pattern used by _apply_contours() and _apply_linefeatures().

### Changes

#### Modified Files

* **`ocsmesh/hfun/raster.py`** — `HfunRaster.add_patch()`:
  - Added `@utils.add_pool_args` decorator and `pool: Pool` kwarg-only parameter
  - Changed internal `add_feature(nprocs=nprocs)` call to `add_feature(pool=pool)` — forwards shared pool instead of spawning a new one
  - Fixed `add_channel()` to pass `nprocs=nprocs` as keyword (was positional, would break with new `*` kwarg barrier)

* **`ocsmesh/hfun/mesh.py`** — `HfunMesh.add_patch()`:
  - Added `@utils.add_pool_args` decorator and `pool: Pool` kwarg-only parameter
  - Changed internal `add_feature(nprocs=nprocs)` call to `add_feature(pool=pool)`

* **`ocsmesh/hfun/collector.py`** — `_apply_patch()` and `_apply_channels()`:
  - Wrapped outer loops in `with Pool(processes=self._nprocs) as p:` context manager
  - Pass `pool=p` to every `hfun.add_patch()` call inside the loop
  - Mirrors the proven pattern from `_apply_contours()` and `_apply_linefeatures()`

#### Tests
* Added 3 serial-vs-parallel equivalence tests to `tests/api/test_collector_pickle.py` (same class, same pattern as existing tests):
  - `test_serial_vs_parallel_patch_equivalence` — patch without expansion_rate
  - `test_serial_vs_parallel_patch_with_expansion_equivalence` — patch with expansion_rate (exercises `add_patch → add_feature(pool=pool)` forwarding)
  - `test_serial_vs_parallel_channel_equivalence` — channel refinement
* Added 3 backward compatibility tests verifying old `nprocs=` API still works:
  - `test_add_patch_backward_compat_nprocs` — calls `HfunRaster.add_patch(nprocs=2)` directly, verifies decorator auto-spawns Pool
  - `test_add_patch_with_expansion_backward_compat_nprocs` — calls `add_patch(nprocs=2, expansion_rate=0.1)`, exercises decorator → `add_feature` forwarding via nprocs
  - `test_add_channel_backward_compat_nprocs` — calls `HfunRaster.add_channel(nprocs=2)` directly, verifies nprocs still accepted
* Follows existing comparison pattern: create serial + parallel `Hfun`, add same refinements, compare `meshdata()` output statistically (node count, min, max, mean)
##### Fix for Windows tearDown crash:
Explicitly cleared raster references and forced garbage collection (gc.collect()) before deleting the temporary directory. This forces GDAL/rasterio to release their file locks immediately so Windows allows the deletion. Also wrapped shutil.rmtree in a try/except to safely ignore any lingering Windows filesystem delays.

#### Notes
* Backward compatible — external callers using `nprocs=` still work via `@add_pool_args` decorator auto-spawn

