### PR TITLE
chore: update Workflow (tests) python versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,10 +25,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        generate-run-shell: false
         create-args: >-
           python=3.12
     - name: Install dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        post-cleanup: 'none'
         generate-run-shell: false
         create-args: >-
           python=3.12

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -35,10 +35,11 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        generate-run-shell: false
         create-args: >-
           python=${{ matrix.python-version }}
 

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        post-cleanup: 'none'
         generate-run-shell: false
         create-args: >-
           python=${{ matrix.python-version }}

--- a/.github/workflows/functional_test.yml
+++ b/.github/workflows/functional_test.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.10', '3.11', '3.12', '3.13'] # TODO:Update to 3.14 when triangle library adds support 
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        post-cleanup: 'none'
         generate-run-shell: false
         create-args: >-
           python=3.14

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -32,7 +32,7 @@ jobs:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
         create-args: >-
-          python=3.12
+          python=3.14
     - name: Install dependencies
       shell: bash -l {0}
       run: pip install .[testing]

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,10 +27,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Mamba environment for Python
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         environment-file: ./environment.yml
         environment-name: ocsmesh-env
+        generate-run-shell: false
         create-args: >-
           python=3.14
     - name: Install dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -33,8 +33,9 @@ jobs:
         environment-name: ocsmesh-env
         post-cleanup: 'none'
         generate-run-shell: false
+        # TODO: Update to 3.14 when triangle library adds support
         create-args: >-
-          python=3.14
+          python=3.13
     - name: Install dependencies
       shell: bash -l {0}
       run: pip install .[testing]

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ocsmesh
 channels:
   - conda-forge
 dependencies:
-  - python >=3.9,<3.13
+  - python >=3.10,<3.15
   - gdal
   - geos
   - proj

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ocsmesh
 channels:
   - conda-forge
 dependencies:
-  - python >=3.10,<3.15
+  - python >=3.10,<3.14 # TODO: Update to <3.15 when triangle library adds support for 3.14
   - gdal
   - geos
   - proj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 description = "Package to generate computational unstructured meshes for ocean simulation."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = '>=3.9, <3.13' # 3.8 -> scipy
+requires-python = '>=3.10, <3.15' # 3.8 -> scipy
 dependencies = [
     "colored-traceback<=0.3.0", 
     "fiona", "geopandas>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 description = "Package to generate computational unstructured meshes for ocean simulation."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = '>=3.10, <3.15' # 3.8 -> scipy
+requires-python = '>=3.10, <3.15'
 dependencies = [
     "colored-traceback<=0.3.0", 
     "fiona", "geopandas>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 description = "Package to generate computational unstructured meshes for ocean simulation."
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = '>=3.10, <3.15'
+requires-python = '>=3.10, <3.14' # TODO: Update to <3.15 when triangle library adds support for 3.14
 dependencies = [
     "colored-traceback<=0.3.0", 
     "fiona", "geopandas>=1.0.0",


### PR DESCRIPTION
### Summary
This PR modernizes CI pipeline and updates the project's supported Python versions to align with recent releases.

* **CURRENT ISSUE on Python 3.14:** Testing on my fork all passed except Python 3.14. This is because the optional `triangle` dependency seems to be outdated and it tries to use internal C headers (`longintrepr.h`) which is no longer accessable. The package was last updated on Jan 2025 with no install support for python 3.14

We can explore this solution:
**Migrate Libraries:** Move away from `triangle` entirely and use alternatives like `scipy.spatial.Delaunay`.

### Update on Previous issue
Addressed for now by dropping 3.14 for now with TODO comments for that when traingle support it.

**Changes Included:**
* **Updated Python Support:** Dropped Python 3.9 and added support for Python 3.13 and 3.14*.
* **Updated Configurations:** Adjusted `pyproject.toml` and `environment.yml` to `python >=3.10, <3.15`.
* **CI Bug Fixes:** Bumped `setup-micromamba` from `v1` to `v3`
* **Cleanup Crash Fix:** Disabled `setup-micromamba`'s post-job cleanup and shell generation steps to stop it from crashing at the very end of successful runs.
* **Linter Update:** Bumped the `pylint.yml` workflow to run using the latest Python environments.
