### PR TITLE
chore: add benchmark_script workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,72 @@
+name: Benchmark
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/benchmark.yml'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Performance Benchmarks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Mamba environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: ./environment.yml
+          environment-name: ocsmesh-env
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: pip install .[testing] pytest-benchmark
+
+      - name: Run benchmarks
+        shell: bash -l {0}
+        run: >
+          python -m pytest tests/benchmarks/benchmark.py
+          --benchmark-only
+          --benchmark-json output.json
+          -v
+
+      - name: Post benchmark results to PR
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: pytest
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Comment-only mode — no gh-pages branch needed
+          auto-push: false
+          save-data-file: false
+          comment-always: true
+          # Flag benchmarks that are >=150% slower than baseline
+          alert-threshold: '150%'
+          comment-on-alert: true
+
+      - name: Post metrics explanation to PR
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const body = `### 📊 Benchmark Metrics Explained
+            - **Min / Max / Mean / Median**: Raw execution times in seconds across all rounds.
+            - **StdDev**: Standard Deviation. A lower value means the runs were very consistent.
+            - **IQR**: Interquartile Range, another variance measure that ignores extreme outliers.
+            - **Outliers (Mild;Severe)**: How many rounds were significantly faster/slower than average.
+            - **OPS**: Operations Per Second (1 / Mean).
+            - **Rounds**: Total number of independent measurements taken.
+            
+            *(The numbers in parentheses, e.g. \`(1.58)\`, represent how many times slower that mode was compared to the absolute fastest mode)*`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,37 +36,85 @@ jobs:
           -v
 
       - name: Post benchmark results to PR
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: pytest
-          output-file-path: output.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Comment-only mode — no gh-pages branch needed
-          auto-push: false
-          save-data-file: false
-          comment-always: true
-          # Flag benchmarks that are >=150% slower than baseline
-          alert-threshold: '150%'
-          comment-on-alert: true
-
-      - name: Post metrics explanation to PR
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:
           script: |
-            const body = `### 📊 Benchmark Metrics Explained
-            - **Min / Max / Mean / Median**: Raw execution times in seconds across all rounds.
-            - **StdDev**: Standard Deviation. A lower value means the runs were very consistent.
-            - **IQR**: Interquartile Range, another variance measure that ignores extreme outliers.
-            - **Outliers (Mild;Severe)**: How many rounds were significantly faster/slower than average.
-            - **OPS**: Operations Per Second (1 / Mean).
-            - **Rounds**: Total number of independent measurements taken.
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('output.json', 'utf8'));
             
-            *(The numbers in parentheses, e.g. \`(1.58)\`, represent how many times slower that mode was compared to the absolute fastest mode)*`;
+            const fullSha = context.payload.pull_request.head.sha;
+            const shortSha = fullSha.substring(0, 7);
+            const branch = context.payload.pull_request.head.ref;
             
-            github.rest.issues.createComment({
+            // Fetch commit message
+            const { data: commitData } = await github.rest.git.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: fullSha,
+            });
+            const commitMsg = commitData.message.split('\n')[0];
+            
+            // Hidden marker to identify this comment for future updates
+            const marker = '<!-- ocsmesh-benchmark-results -->';
+            
+            // Find fastest mean to calculate ratios
+            const minMean = Math.min(...data.benchmarks.map(b => b.stats.mean));
+            
+            let body = `${marker}\n`;
+            body += `### Performance Benchmark Results\n\n`;
+            body += `| | |\n`;
+            body += `|---|---|\n`;
+            body += `| **Branch** | \`${branch}\` |\n`;
+            body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n\n`;
+            body += `| Mode | Mean Time | Min | Max | StdDev | OPS |\n`;
+            body += `|------|-----------|-----|-----|--------|-----|\n`;
+            
+            data.benchmarks.forEach(b => {
+              const name = b.name.replace('test_meshdata_pipeline[', '').replace(']', '');
+              
+              const mean = b.stats.mean.toFixed(2);
+              const min = b.stats.min.toFixed(2);
+              const max = b.stats.max.toFixed(2);
+              const stddev = b.stats.stddev.toFixed(3);
+              const ops = b.stats.ops.toFixed(3);
+              
+              const ratio = (b.stats.mean / minMean).toFixed(2);
+              const ratioStr = ratio === "1.00" ? "(fastest)" : `(${ratio}x slower)`;
+              const meanStr = `**${mean}s** ${ratioStr}`;
+              
+              body += `| **${name}** | ${meanStr} | ${min}s | ${max}s | ${stddev} | ${ops} |\n`;
+            });
+            
+            body += `\n<br>\n\n`;
+            body += `<sub>\n`;
+            body += `<b>Metrics:</b> `;
+            body += `<b>Mean / Min / Max</b>: execution times in seconds. `;
+            body += `<b>StdDev</b>: variance between runs. `;
+            body += `<b>OPS</b>: operations per second (1 / Mean). `;
+            body += `<i>Parentheses show relative speed compared to the fastest mode.</i>\n`;
+            body += `</sub>`;
+            
+            // Find existing benchmark comment by marker
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body
-            })
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body,
+              });
+            }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,12 +61,15 @@ jobs:
             // Find fastest mean to calculate ratios
             const minMean = Math.min(...data.benchmarks.map(b => b.stats.mean));
             
+            const rounds = data.benchmarks[0].stats.rounds;
+            
             let body = `${marker}\n`;
             body += `### Performance Benchmark Results\n\n`;
             body += `| | |\n`;
             body += `|---|---|\n`;
             body += `| **Branch** | \`${branch}\` |\n`;
-            body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n\n`;
+            body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n`;
+            body += `| **Rounds** | ${rounds} |\n\n`;
             body += `| Mode | Mean Time | Min | Max | StdDev | OPS |\n`;
             body += `|------|-----------|-----|-----|--------|-----|\n`;
             
@@ -85,6 +88,23 @@ jobs:
               
               body += `| **${name}** | ${meanStr} | ${min}s | ${max}s | ${stddev} | ${ops} |\n`;
             });
+            
+            // Numerical equivalence check status
+            body += `\n`;
+            try {
+              const eq = JSON.parse(fs.readFileSync('equivalence_result.json', 'utf8'));
+              body += `**Numerical Equivalence:** PASS — \`${eq.first_mode}\` vs \`${eq.second_mode}\` (tolerance: ${eq.rtol})\n\n`;
+              body += `| Metric | ${eq.first_mode} | ${eq.second_mode} | Relative Diff |\n`;
+              body += `|--------|${'-'.repeat(eq.first_mode.length + 2)}|${'-'.repeat(eq.second_mode.length + 2)}|----------------|\n`;
+              
+              const c = eq.checks;
+              body += `| **Nodes** | ${c.num_nodes.first} | ${c.num_nodes.second} | ${c.num_nodes.match ? 'exact match' : 'MISMATCH'} |\n`;
+              body += `| **Min** | ${c.min.first.toFixed(6)} | ${c.min.second.toFixed(6)} | ${c.min.rel_diff.toExponential(2)} |\n`;
+              body += `| **Max** | ${c.max.first.toFixed(6)} | ${c.max.second.toFixed(6)} | ${c.max.rel_diff.toExponential(2)} |\n`;
+              body += `| **Mean** | ${c.mean.first.toFixed(6)} | ${c.mean.second.toFixed(6)} | ${c.mean.rel_diff.toExponential(2)} |\n`;
+            } catch (e) {
+              body += `**Numerical Equivalence:** status unavailable (equivalence_result.json not found)\n`;
+            }
             
             body += `\n<br>\n\n`;
             body += `<sub>\n`;

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,15 +93,19 @@ jobs:
             body += `\n`;
             try {
               const eq = JSON.parse(fs.readFileSync('equivalence_result.json', 'utf8'));
-              body += `**Numerical Equivalence:** PASS — \`${eq.first_mode}\` vs \`${eq.second_mode}\` (tolerance: ${eq.rtol})\n\n`;
-              body += `| Metric | ${eq.first_mode} | ${eq.second_mode} | Relative Diff |\n`;
-              body += `|--------|${'-'.repeat(eq.first_mode.length + 2)}|${'-'.repeat(eq.second_mode.length + 2)}|----------------|\n`;
+              const modes = Object.keys(eq.comparisons);
+              body += `**Numerical Equivalence:** PASS (baseline: \`${eq.baseline}\`, tolerance: ${eq.rtol})\n\n`;
               
-              const c = eq.checks;
-              body += `| **Nodes** | ${c.num_nodes.first} | ${c.num_nodes.second} | ${c.num_nodes.match ? 'exact match' : 'MISMATCH'} |\n`;
-              body += `| **Min** | ${c.min.first.toFixed(6)} | ${c.min.second.toFixed(6)} | ${c.min.rel_diff.toExponential(2)} |\n`;
-              body += `| **Max** | ${c.max.first.toFixed(6)} | ${c.max.second.toFixed(6)} | ${c.max.rel_diff.toExponential(2)} |\n`;
-              body += `| **Mean** | ${c.mean.first.toFixed(6)} | ${c.mean.second.toFixed(6)} | ${c.mean.rel_diff.toExponential(2)} |\n`;
+              for (const mode of modes) {
+                const c = eq.comparisons[mode];
+                body += `\`${eq.baseline}\` vs \`${mode}\`\n\n`;
+                body += `| Metric | ${eq.baseline} | ${mode} | Relative Diff |\n`;
+                body += `|--------|--------|--------|----------------|\n`;
+                body += `| **Nodes** | ${c.num_nodes.baseline} | ${c.num_nodes.current} | ${c.num_nodes.match ? 'exact match' : 'MISMATCH'} |\n`;
+                body += `| **Min** | ${c.min.baseline.toFixed(6)} | ${c.min.current.toFixed(6)} | ${c.min.rel_diff.toExponential(2)} |\n`;
+                body += `| **Max** | ${c.max.baseline.toFixed(6)} | ${c.max.current.toFixed(6)} | ${c.max.rel_diff.toExponential(2)} |\n`;
+                body += `| **Mean** | ${c.mean.baseline.toFixed(6)} | ${c.mean.current.toFixed(6)} | ${c.mean.rel_diff.toExponential(2)} |\n\n`;
+              }
             } catch (e) {
               body += `**Numerical Equivalence:** status unavailable (equivalence_result.json not found)\n`;
             }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,6 @@ jobs:
         shell: bash -l {0}
         run: >
           python -m pytest tests/benchmarks/benchmark.py
-          --benchmark-only
           --benchmark-json output.json
           -v
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
             body += `|---|---|\n`;
             body += `| **Branch** | \`${branch}\` |\n`;
             body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n`;
-            body += `| **Rounds** | ${rounds} |\n\n`;
+            body += `| **Rounds "Runs"** | ${rounds} |\n\n`;
             body += `| Mode | Mean Time | Min | Max | StdDev | OPS |\n`;
             body += `|------|-----------|-----|-----|--------|-----|\n`;
             
@@ -108,7 +108,7 @@ jobs:
             
             body += `\n<br>\n\n`;
             body += `<sub>\n`;
-            body += `<b>Metrics:</b> `;
+            body += `<b>Performance Metrics:</b> `;
             body += `<b>Mean / Min / Max</b>: execution times in seconds. `;
             body += `<b>StdDev</b>: variance between runs. `;
             body += `<b>OPS</b>: operations per second (1 / Mean). `;

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,8 @@ on:
       - '.github/workflows/benchmark.yml'
 
 permissions:
+  contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,9 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  # TODO: It was left for security issues we are now using artificat instead
+  # issues: write
+  # pull-requests: write
 
 jobs:
   benchmark:
@@ -36,110 +37,126 @@ jobs:
           --benchmark-json output.json
           -v
 
-      - name: Post benchmark results to PR
-        uses: actions/github-script@v7
-        if: github.event_name == 'pull_request'
+      - name: Generate report
+        shell: bash -l {0}
+        run: python tests/benchmarks/generate_report.py
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const fs = require('fs');
-            const data = JSON.parse(fs.readFileSync('output.json', 'utf8'));
-            
-            const fullSha = context.payload.pull_request.head.sha;
-            const shortSha = fullSha.substring(0, 7);
-            const branch = context.payload.pull_request.head.ref;
-            
-            // Fetch commit message
-            const { data: commitData } = await github.rest.git.getCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: fullSha,
-            });
-            const commitMsg = commitData.message.split('\n')[0];
-            
-            // Hidden marker to identify this comment for future updates
-            const marker = '<!-- ocsmesh-benchmark-results -->';
-            
-            // Find fastest mean to calculate ratios
-            const minMean = Math.min(...data.benchmarks.map(b => b.stats.mean));
-            
-            const rounds = data.benchmarks[0].stats.rounds;
-            
-            let body = `${marker}\n`;
-            body += `### Performance Benchmark Results\n\n`;
-            body += `| | |\n`;
-            body += `|---|---|\n`;
-            body += `| **Branch** | \`${branch}\` |\n`;
-            body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n`;
-            body += `| **Rounds "Runs"** | ${rounds} |\n\n`;
-            body += `| Mode | Mean Time | Min | Max | StdDev | OPS |\n`;
-            body += `|------|-----------|-----|-----|--------|-----|\n`;
-            
-            data.benchmarks.forEach(b => {
-              const name = b.name.replace('test_meshdata_pipeline[', '').replace(']', '');
-              
-              const mean = b.stats.mean.toFixed(2);
-              const min = b.stats.min.toFixed(2);
-              const max = b.stats.max.toFixed(2);
-              const stddev = b.stats.stddev.toFixed(3);
-              const ops = b.stats.ops.toFixed(3);
-              
-              const ratio = (b.stats.mean / minMean).toFixed(2);
-              const ratioStr = ratio === "1.00" ? "(fastest)" : `(${ratio}x slower)`;
-              const meanStr = `**${mean}s** ${ratioStr}`;
-              
-              body += `| **${name}** | ${meanStr} | ${min}s | ${max}s | ${stddev} | ${ops} |\n`;
-            });
-            
-            // Numerical equivalence check status
-            body += `\n`;
-            try {
-              const eq = JSON.parse(fs.readFileSync('equivalence_result.json', 'utf8'));
-              const modes = Object.keys(eq.comparisons);
-              body += `**Numerical Equivalence:** PASS (baseline: \`${eq.baseline}\`, tolerance: ${eq.rtol})\n\n`;
-              
-              for (const mode of modes) {
-                const c = eq.comparisons[mode];
-                body += `\`${eq.baseline}\` vs \`${mode}\`\n\n`;
-                body += `| Metric | ${eq.baseline} | ${mode} | Relative Diff |\n`;
-                body += `|--------|--------|--------|----------------|\n`;
-                body += `| **Nodes** | ${c.num_nodes.baseline} | ${c.num_nodes.current} | ${c.num_nodes.match ? 'exact match' : 'MISMATCH'} |\n`;
-                body += `| **Min** | ${c.min.baseline.toFixed(6)} | ${c.min.current.toFixed(6)} | ${c.min.rel_diff.toExponential(2)} |\n`;
-                body += `| **Max** | ${c.max.baseline.toFixed(6)} | ${c.max.current.toFixed(6)} | ${c.max.rel_diff.toExponential(2)} |\n`;
-                body += `| **Mean** | ${c.mean.baseline.toFixed(6)} | ${c.mean.current.toFixed(6)} | ${c.mean.rel_diff.toExponential(2)} |\n\n`;
-              }
-            } catch (e) {
-              body += `**Numerical Equivalence:** status unavailable (equivalence_result.json not found)\n`;
-            }
-            
-            body += `\n<br>\n\n`;
-            body += `<sub>\n`;
-            body += `<b>Performance Metrics:</b> `;
-            body += `<b>Mean / Min / Max</b>: execution times in seconds. `;
-            body += `<b>StdDev</b>: variance between runs. `;
-            body += `<b>OPS</b>: operations per second (1 / Mean). `;
-            body += `<i>Parentheses show relative speed compared to the fastest mode.</i>\n`;
-            body += `</sub>`;
-            
-            // Find existing benchmark comment by marker
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-            
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: body,
-              });
-            }
+          name: benchmark-results
+          path: |
+            benchmark_report.txt
+            output.json
+            equivalence_result.json
+
+      # TODO: It was left for security issues we are now using artificat instead
+      # NOTE: Was tested on github-script@v7 we should consider v9 or v8
+      # - name: Post benchmark results to PR (as a comment)
+      #   uses: actions/github-script@v7
+      #   if: github.event_name == 'pull_request'
+      #   with:
+      #     script: |
+        # const fs = require('fs');
+        # const data = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+        
+        # const fullSha = context.payload.pull_request.head.sha;
+        # const shortSha = fullSha.substring(0, 7);
+        # const branch = context.payload.pull_request.head.ref;
+        
+        # // Fetch commit message
+        # const { data: commitData } = await github.rest.git.getCommit({
+        #   owner: context.repo.owner,
+        #   repo: context.repo.repo,
+        #   commit_sha: fullSha,
+        # });
+        # const commitMsg = commitData.message.split('\n')[0];
+        
+        # // Hidden marker to identify this comment for future updates
+        # const marker = '<!-- ocsmesh-benchmark-results -->';
+        
+        # // Find fastest mean to calculate ratios
+        # const minMean = Math.min(...data.benchmarks.map(b => b.stats.mean));
+        
+        # const rounds = data.benchmarks[0].stats.rounds;
+        
+        # let body = `${marker}\n`;
+        # body += `### Performance Benchmark Results\n\n`;
+        # body += `| | |\n`;
+        # body += `|---|---|\n`;
+        # body += `| **Branch** | \`${branch}\` |\n`;
+        # body += `| **Commit** | \`${shortSha}\` — ${commitMsg} |\n`;
+        # body += `| **Rounds "Runs"** | ${rounds} |\n\n`;
+        # body += `| Mode | Mean Time | Min | Max | StdDev | OPS |\n`;
+        # body += `|------|-----------|-----|-----|--------|-----|\n`;
+        
+        # data.benchmarks.forEach(b => {
+        #   const name = b.name.replace('test_meshdata_pipeline[', '').replace(']', '');
+          
+        #   const mean = b.stats.mean.toFixed(2);
+        #   const min = b.stats.min.toFixed(2);
+        #   const max = b.stats.max.toFixed(2);
+        #   const stddev = b.stats.stddev.toFixed(3);
+        #   const ops = b.stats.ops.toFixed(3);
+          
+        #   const ratio = (b.stats.mean / minMean).toFixed(2);
+        #   const ratioStr = ratio === "1.00" ? "(fastest)" : `(${ratio}x slower)`;
+        #   const meanStr = `**${mean}s** ${ratioStr}`;
+          
+        #   body += `| **${name}** | ${meanStr} | ${min}s | ${max}s | ${stddev} | ${ops} |\n`;
+        # });
+        
+        # // Numerical equivalence check status
+        # body += `\n`;
+        # try {
+        #   const eq = JSON.parse(fs.readFileSync('equivalence_result.json', 'utf8'));
+        #   const modes = Object.keys(eq.comparisons);
+        #   body += `**Numerical Equivalence:** PASS (baseline: \`${eq.baseline}\`, tolerance: ${eq.rtol})\n\n`;
+          
+        #   for (const mode of modes) {
+        #     const c = eq.comparisons[mode];
+        #     body += `\`${eq.baseline}\` vs \`${mode}\`\n\n`;
+        #     body += `| Metric | ${eq.baseline} | ${mode} | Relative Diff |\n`;
+        #     body += `|--------|--------|--------|----------------|\n`;
+        #     body += `| **Nodes** | ${c.num_nodes.baseline} | ${c.num_nodes.current} | ${c.num_nodes.match ? 'exact match' : 'MISMATCH'} |\n`;
+        #     body += `| **Min** | ${c.min.baseline.toFixed(6)} | ${c.min.current.toFixed(6)} | ${c.min.rel_diff.toExponential(2)} |\n`;
+        #     body += `| **Max** | ${c.max.baseline.toFixed(6)} | ${c.max.current.toFixed(6)} | ${c.max.rel_diff.toExponential(2)} |\n`;
+        #     body += `| **Mean** | ${c.mean.baseline.toFixed(6)} | ${c.mean.current.toFixed(6)} | ${c.mean.rel_diff.toExponential(2)} |\n\n`;
+        #   }
+        # } catch (e) {
+        #   body += `**Numerical Equivalence:** status unavailable (equivalence_result.json not found)\n`;
+        # }
+        
+        # body += `\n<br>\n\n`;
+        # body += `<sub>\n`;
+        # body += `<b>Performance Metrics:</b> `;
+        # body += `<b>Mean / Min / Max</b>: execution times in seconds. `;
+        # body += `<b>StdDev</b>: variance between runs. `;
+        # body += `<b>OPS</b>: operations per second (1 / Mean). `;
+        # body += `<i>Parentheses show relative speed compared to the fastest mode.</i>\n`;
+        # body += `</sub>`;
+        
+        # // Find existing benchmark comment by marker
+        # const { data: comments } = await github.rest.issues.listComments({
+        #   issue_number: context.issue.number,
+        #   owner: context.repo.owner,
+        #   repo: context.repo.repo,
+        # });
+        # const existing = comments.find(c => c.body.includes(marker));
+        
+        # if (existing) {
+        #   await github.rest.issues.updateComment({
+        #     owner: context.repo.owner,
+        #     repo: context.repo.repo,
+        #     comment_id: existing.id,
+        #     body: body,
+        #   });
+        # } else {
+        #   await github.rest.issues.createComment({
+        #     issue_number: context.issue.number,
+        #     owner: context.repo.owner,
+        #     repo: context.repo.repo,
+        #     body: body,
+        #   });
+        # }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ocsmesh = "ocsmesh.__main__:main"
 [project.optional-dependencies]
 gmsh = ["gmsh"]
 triangle = ["triangle"]
-testing = ['pylint>=2.14','triangle','gmsh']
+testing = ['pylint>=2.14','triangle','gmsh','pytest-benchmark']
 documentation = [
     'sphinx < 7.0.0', # due to sphinx_rtd_theme support
     'sphinx-rtd-theme', 'sphinx-argparse',

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -1,0 +1,94 @@
+"""
+Benchmarks for the meshdata() pipeline.
+
+NOTE: Since this file is named `benchmark.py` (and does not start with `test_`),
+pytest won't discover it automatically if you just run `pytest tests/`.
+It will only run if you specifically pass the file path: `pytest tests/benchmarks/benchmark.py`.
+This is ideal for benchmarks so they don't slow down normal unit test runs.
+
+Uses ``pytest-benchmark`` to measure the full ``hfun.meshdata()``
+pipeline under different execution configurations. Results are
+consumed by ``github-action-benchmark`` in CI to post comparison
+tables directly as PR comments.
+
+Run locally::
+
+    pytest tests/benchmarks/benchmark.py --benchmark-only -v
+
+Generate JSON for CI::
+
+    pytest tests/benchmarks/benchmark.py --benchmark-only --benchmark-json output.json
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from ocsmesh import Hfun
+
+
+# ─── Benchmark Configuration ────────────────────────────────────────
+# Edit rounds here to control how many times each mode is measured.
+# Higher rounds = more stable statistics but slower CI.
+BENCHMARK_ROUNDS = 3
+
+# Dictionary to cache the first result to assert numerical equivalence
+_CACHED_RESULTS = {}
+
+
+# ─── Test Case Definitions ──────────────────────────────────────────
+BENCHMARK_CASES = ["serial", "parallel"]
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+def _build_hfun(raster_list, execution_mode):
+    """Create an Hfun with 3 refinements and the given execution_mode."""
+
+    hfun = Hfun(raster_list, nprocs=4, hmin=10, hmax=1000)
+    hfun.execution_mode = execution_mode
+    hfun.add_topo_bound_constraint(
+        value=100, upper_bound=5, lower_bound=-5, value_type='min')
+    hfun.add_topo_bound_constraint(
+        value=200, upper_bound=8, lower_bound=2, value_type='max')
+    hfun.add_constant_value(value=500, lower_bound=-10, upper_bound=-5)
+    return hfun
+
+
+# ─── Benchmarks ──────────────────────────────────────────────────────
+
+@pytest.mark.benchmark(group="meshdata_pipeline")
+@pytest.mark.parametrize("exec_mode", BENCHMARK_CASES)
+def test_meshdata_pipeline(benchmark, benchmark_raster_list, exec_mode):
+    """Benchmark hfun.meshdata() under a specific execution configuration.
+
+    The ``benchmark_raster_list`` fixture (from conftest.py) provides
+    4 tiled rasters with 20% overlap, created once per module.
+    """
+
+    def run_meshdata():
+        hfun = _build_hfun(benchmark_raster_list, exec_mode)
+        return hfun.meshdata()
+
+    meshdata = benchmark.pedantic(
+        run_meshdata,
+        rounds=BENCHMARK_ROUNDS,
+    )
+
+    # Sanity checks
+    assert meshdata is not None
+    assert len(meshdata.coords) > 0
+    assert np.all(np.isfinite(meshdata.values))
+
+    # Equivalence checks across modes
+    mean_val = float(np.mean(meshdata.values))
+    
+    if not _CACHED_RESULTS:
+        _CACHED_RESULTS["mean_val"] = mean_val
+    else:
+        npt.assert_allclose(
+            _CACHED_RESULTS["mean_val"], 
+            mean_val, 
+            rtol=1e-5,
+            err_msg=f"Mean value mismatch in {exec_mode} mode"
+        )

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -3,8 +3,6 @@ Benchmarks for the meshdata() pipeline.
 
 NOTE: Since this file is named `benchmark.py` (and does not start with `test_`),
 pytest won't discover it automatically if you just run `pytest tests/`.
-It will only run if you specifically pass the file path: `pytest tests/benchmarks/benchmark.py`.
-This is ideal for benchmarks so they don't slow down normal unit test runs.
 
 Uses ``pytest-benchmark`` to measure the full ``hfun.meshdata()``
 pipeline under different execution configurations. Results are
@@ -28,7 +26,6 @@ from ocsmesh import Hfun
 
 # ─── Benchmark Configuration ────────────────────────────────────────
 # Edit rounds here to control how many times each mode is measured.
-# Higher rounds = more stable statistics but slower CI.
 BENCHMARK_ROUNDS = 3
 
 # Dictionary to cache the first result to assert numerical equivalence
@@ -40,6 +37,7 @@ BENCHMARK_CASES = ["serial", "parallel"]
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────
+# TODO: this can be extended to cover more refinement scenarios.
 
 def _build_hfun(raster_list, execution_mode):
     """Create an Hfun with 3 refinements and the given execution_mode."""
@@ -83,8 +81,8 @@ def test_meshdata_pipeline(benchmark, benchmark_raster_list, exec_mode):
     mean_val = float(np.mean(meshdata.values))
     
     if not _CACHED_RESULTS:
-        _CACHED_RESULTS["mean_val"] = mean_val
-    else:
+        _CACHED_RESULTS["mean_val"] = mean_val # cache the first result for comparison.
+    else: # compare with cached result
         npt.assert_allclose(
             _CACHED_RESULTS["mean_val"], 
             mean_val, 

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -8,8 +8,7 @@ This is ideal for benchmarks so they don't slow down normal unit test runs.
 
 Uses ``pytest-benchmark`` to measure the full ``hfun.meshdata()``
 pipeline under different execution configurations. Results are
-consumed by ``github-action-benchmark`` in CI to post comparison
-tables directly as PR comments.
+parsed by the CI workflow and posted as PR comments.
 
 Run locally::
 

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -17,6 +17,9 @@ Generate JSON for CI::
     pytest tests/benchmarks/benchmark.py --benchmark-only --benchmark-json output.json
 """
 
+import json
+from pathlib import Path
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -28,8 +31,14 @@ from ocsmesh import Hfun
 # Edit rounds here to control how many times each mode is measured.
 BENCHMARK_ROUNDS = 3
 
+# Relative tolerance for the numerical equivalence check
+EQUIVALENCE_RTOL = 1e-5
+
 # Dictionary to cache the first result to assert numerical equivalence
 _CACHED_RESULTS = {}
+
+# Path to write equivalence check results for CI reporting
+_EQUIVALENCE_OUTPUT = Path("equivalence_result.json")
 
 
 # ─── Test Case Definitions ──────────────────────────────────────────
@@ -50,6 +59,32 @@ def _build_hfun(raster_list, execution_mode):
         value=200, upper_bound=8, lower_bound=2, value_type='max')
     hfun.add_constant_value(value=500, lower_bound=-10, upper_bound=-5)
     return hfun
+
+
+def _write_equivalence_result(status, first_mode, second_mode, checks, rtol):
+    """Write equivalence check outcome to a JSON file for CI reporting.
+
+    Parameters
+    ----------
+    status : str
+        'pass' or 'fail'.
+    first_mode, second_mode : str
+        The execution modes being compared.
+    checks : dict
+        Per-metric comparison results, e.g.
+        {"num_nodes": {"first": 100, "second": 100, "match": True}, ...}
+    rtol : float
+        Relative tolerance used for floating-point comparisons.
+    """
+
+    result = {
+        "status": status,
+        "first_mode": first_mode,
+        "second_mode": second_mode,
+        "rtol": rtol,
+        "checks": checks,
+    }
+    _EQUIVALENCE_OUTPUT.write_text(json.dumps(result, indent=2))
 
 
 # ─── Benchmarks ──────────────────────────────────────────────────────
@@ -77,15 +112,79 @@ def test_meshdata_pipeline(benchmark, benchmark_raster_list, exec_mode):
     assert len(meshdata.coords) > 0
     assert np.all(np.isfinite(meshdata.values))
 
-    # Equivalence checks across modes
-    mean_val = float(np.mean(meshdata.values))
-    
+    # Cache results from the first mode for cross-mode comparison
+    stats = {
+        "num_nodes": len(meshdata.coords),
+        "min": float(np.min(meshdata.values)),
+        "max": float(np.max(meshdata.values)),
+        "mean": float(np.mean(meshdata.values)),
+        "coords": meshdata.coords,
+    }
+
     if not _CACHED_RESULTS:
-        _CACHED_RESULTS["mean_val"] = mean_val # cache the first result for comparison.
-    else: # compare with cached result
-        npt.assert_allclose(
-            _CACHED_RESULTS["mean_val"], 
-            mean_val, 
-            rtol=1e-5,
-            err_msg=f"Mean value mismatch in {exec_mode} mode"
+        _CACHED_RESULTS["mode"] = exec_mode
+        _CACHED_RESULTS["stats"] = stats
+    else:
+        cached = _CACHED_RESULTS["stats"]
+
+        # Build per-metric check results for CI reporting
+        checks = {
+            "num_nodes": {
+                "first": cached["num_nodes"],
+                "second": stats["num_nodes"],
+                "match": cached["num_nodes"] == stats["num_nodes"],
+            },
+            "min": {
+                "first": cached["min"],
+                "second": stats["min"],
+                "rel_diff": abs(cached["min"] - stats["min"]) / abs(cached["min"]) if cached["min"] != 0 else 0.0,
+            },
+            "max": {
+                "first": cached["max"],
+                "second": stats["max"],
+                "rel_diff": abs(cached["max"] - stats["max"]) / abs(cached["max"]) if cached["max"] != 0 else 0.0,
+            },
+            "mean": {
+                "first": cached["mean"],
+                "second": stats["mean"],
+                "rel_diff": abs(cached["mean"] - stats["mean"]) / abs(cached["mean"]) if cached["mean"] != 0 else 0.0,
+            },
+        }
+
+        _write_equivalence_result(
+            status="pass",
+            first_mode=_CACHED_RESULTS["mode"],
+            second_mode=exec_mode,
+            checks=checks,
+            rtol=EQUIVALENCE_RTOL,
         )
+
+        # Node count must match exactly
+        assert cached["num_nodes"] == stats["num_nodes"], (
+            f"Node count mismatch: {cached['num_nodes']} vs {stats['num_nodes']}"
+        )
+
+        # Coordinates must match within tolerance
+        npt.assert_allclose(
+            cached["coords"], stats["coords"],
+            rtol=EQUIVALENCE_RTOL,
+            err_msg=f"Coordinates mismatch in {exec_mode} mode",
+        )
+
+        # Value statistics must match within tolerance
+        npt.assert_allclose(
+            cached["min"], stats["min"],
+            rtol=EQUIVALENCE_RTOL,
+            err_msg=f"Min value mismatch in {exec_mode} mode",
+        )
+        npt.assert_allclose(
+            cached["max"], stats["max"],
+            rtol=EQUIVALENCE_RTOL,
+            err_msg=f"Max value mismatch in {exec_mode} mode",
+        )
+        npt.assert_allclose(
+            cached["mean"], stats["mean"],
+            rtol=EQUIVALENCE_RTOL,
+            err_msg=f"Mean value mismatch in {exec_mode} mode",
+        )
+

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -33,7 +33,7 @@ BENCHMARK_ROUNDS = 3
 
 # Relative tolerance for the numerical equivalence check
 EQUIVALENCE_RTOL = 1e-5
-
+# TODO: Make this configurable via pytest command line option
 # Path to write equivalence check results for CI reporting
 _EQUIVALENCE_OUTPUT = Path("equivalence_result.json")
 

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -14,7 +14,7 @@ Run locally::
 
 Generate JSON for CI::
 
-    pytest tests/benchmarks/benchmark.py --benchmark-only --benchmark-json output.json
+    pytest tests/benchmarks/benchmark.py --benchmark-json output.json
 """
 
 import json

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -34,19 +34,21 @@ BENCHMARK_ROUNDS = 3
 # Relative tolerance for the numerical equivalence check
 EQUIVALENCE_RTOL = 1e-5
 
-# Dictionary to cache the first result to assert numerical equivalence
-_CACHED_RESULTS = {}
-
 # Path to write equivalence check results for CI reporting
 _EQUIVALENCE_OUTPUT = Path("equivalence_result.json")
 
 
 # ─── Test Case Definitions ──────────────────────────────────────────
+# The first entry is used as the
+# baseline for all equivalence comparisons.
 BENCHMARK_CASES = ["serial", "parallel"]
 
 
+# ─── Collected Results ──────────────────────────────────────────────
+_RESULTS = {}
+
+
 # ─── Helpers ─────────────────────────────────────────────────────────
-# TODO: this can be extended to cover more refinement scenarios.
 
 def _build_hfun(raster_list, execution_mode):
     """Create an Hfun with 3 refinements and the given execution_mode."""
@@ -61,30 +63,82 @@ def _build_hfun(raster_list, execution_mode):
     return hfun
 
 
-def _write_equivalence_result(status, first_mode, second_mode, checks, rtol):
-    """Write equivalence check outcome to a JSON file for CI reporting.
+def _extract_stats(meshdata):
+    """Extract comparable statistics from a meshdata result."""
+
+    return {
+        "num_nodes": len(meshdata.coords),
+        "min": float(np.min(meshdata.values)),
+        "max": float(np.max(meshdata.values)),
+        "mean": float(np.mean(meshdata.values)),
+        "coords": meshdata.coords,
+    }
+
+
+def _rel_diff(a, b):
+    """Compute the relative difference between two scalars."""
+
+    return abs(a - b) / abs(a) if a != 0 else 0.0
+
+
+def _compare_stats(baseline, current):
+    """Compare two stat dicts and return a per-metric check summary.
 
     Parameters
     ----------
-    status : str
-        'pass' or 'fail'.
-    first_mode, second_mode : str
-        The execution modes being compared.
-    checks : dict
-        Per-metric comparison results, e.g.
-        {"num_nodes": {"first": 100, "second": 100, "match": True}, ...}
-    rtol : float
-        Relative tolerance used for floating-point comparisons.
+    baseline, current : dict
+        Output of ``_extract_stats``.
+
+    Returns
+    -------
+    dict
+        Per-metric check results suitable for JSON serialization.
     """
 
-    result = {
-        "status": status,
-        "first_mode": first_mode,
-        "second_mode": second_mode,
-        "rtol": rtol,
-        "checks": checks,
+    return {
+        "num_nodes": {
+            "baseline": baseline["num_nodes"],
+            "current": current["num_nodes"],
+            "match": baseline["num_nodes"] == current["num_nodes"],
+        },
+        "min": {
+            "baseline": baseline["min"],
+            "current": current["min"],
+            "rel_diff": _rel_diff(baseline["min"], current["min"]),
+        },
+        "max": {
+            "baseline": baseline["max"],
+            "current": current["max"],
+            "rel_diff": _rel_diff(baseline["max"], current["max"]),
+        },
+        "mean": {
+            "baseline": baseline["mean"],
+            "current": current["mean"],
+            "rel_diff": _rel_diff(baseline["mean"], current["mean"]),
+        },
     }
-    _EQUIVALENCE_OUTPUT.write_text(json.dumps(result, indent=2))
+
+
+def _assert_stats_equal(baseline, current, mode_label, rtol):
+    """Assert that two stat dicts are numerically equivalent."""
+
+    assert baseline["num_nodes"] == current["num_nodes"], (
+        f"[{mode_label}] Node count mismatch: "
+        f"{baseline['num_nodes']} vs {current['num_nodes']}"
+    )
+
+    npt.assert_allclose(
+        baseline["coords"], current["coords"],
+        rtol=rtol,
+        err_msg=f"[{mode_label}] Coordinates mismatch",
+    )
+
+    for metric in ("min", "max", "mean"):
+        npt.assert_allclose(
+            baseline[metric], current[metric],
+            rtol=rtol,
+            err_msg=f"[{mode_label}] {metric} value mismatch",
+        )
 
 
 # ─── Benchmarks ──────────────────────────────────────────────────────
@@ -96,6 +150,8 @@ def test_meshdata_pipeline(benchmark, benchmark_raster_list, exec_mode):
 
     The ``benchmark_raster_list`` fixture (from conftest.py) provides
     4 tiled rasters with 20% overlap, created once per module.
+
+    Results are stored in ``_RESULTS`` for the equivalence test below.
     """
 
     def run_meshdata():
@@ -112,79 +168,39 @@ def test_meshdata_pipeline(benchmark, benchmark_raster_list, exec_mode):
     assert len(meshdata.coords) > 0
     assert np.all(np.isfinite(meshdata.values))
 
-    # Cache results from the first mode for cross-mode comparison
-    stats = {
-        "num_nodes": len(meshdata.coords),
-        "min": float(np.min(meshdata.values)),
-        "max": float(np.max(meshdata.values)),
-        "mean": float(np.mean(meshdata.values)),
-        "coords": meshdata.coords,
+    # Store for cross-mode comparison
+    _RESULTS[exec_mode] = _extract_stats(meshdata)
+
+
+# ─── Equivalence ─────────────────────────────────────────────────────
+
+def test_numerical_equivalence():
+    """Verify that all execution modes produce identical meshdata.
+
+    Runs after all parametrized benchmarks. Uses the first entry in
+    ``BENCHMARK_CASES`` as the baseline and compares every other mode
+    against it. Writes a detailed JSON report for the CI workflow.
+    """
+
+    assert len(_RESULTS) == len(BENCHMARK_CASES), (
+        f"Expected results for {BENCHMARK_CASES}, "
+        f"got results for {list(_RESULTS.keys())}"
+    )
+
+    baseline_mode = BENCHMARK_CASES[0]
+    baseline = _RESULTS[baseline_mode]
+
+    comparisons = {}
+    for mode in BENCHMARK_CASES[1:]:
+        current = _RESULTS[mode]
+        comparisons[mode] = _compare_stats(baseline, current)
+        _assert_stats_equal(baseline, current, mode, EQUIVALENCE_RTOL)
+
+    # Write report for CI
+    report = {
+        "status": "pass",
+        "baseline": baseline_mode,
+        "rtol": EQUIVALENCE_RTOL,
+        "comparisons": comparisons,
     }
-
-    if not _CACHED_RESULTS:
-        _CACHED_RESULTS["mode"] = exec_mode
-        _CACHED_RESULTS["stats"] = stats
-    else:
-        cached = _CACHED_RESULTS["stats"]
-
-        # Build per-metric check results for CI reporting
-        checks = {
-            "num_nodes": {
-                "first": cached["num_nodes"],
-                "second": stats["num_nodes"],
-                "match": cached["num_nodes"] == stats["num_nodes"],
-            },
-            "min": {
-                "first": cached["min"],
-                "second": stats["min"],
-                "rel_diff": abs(cached["min"] - stats["min"]) / abs(cached["min"]) if cached["min"] != 0 else 0.0,
-            },
-            "max": {
-                "first": cached["max"],
-                "second": stats["max"],
-                "rel_diff": abs(cached["max"] - stats["max"]) / abs(cached["max"]) if cached["max"] != 0 else 0.0,
-            },
-            "mean": {
-                "first": cached["mean"],
-                "second": stats["mean"],
-                "rel_diff": abs(cached["mean"] - stats["mean"]) / abs(cached["mean"]) if cached["mean"] != 0 else 0.0,
-            },
-        }
-
-        _write_equivalence_result(
-            status="pass",
-            first_mode=_CACHED_RESULTS["mode"],
-            second_mode=exec_mode,
-            checks=checks,
-            rtol=EQUIVALENCE_RTOL,
-        )
-
-        # Node count must match exactly
-        assert cached["num_nodes"] == stats["num_nodes"], (
-            f"Node count mismatch: {cached['num_nodes']} vs {stats['num_nodes']}"
-        )
-
-        # Coordinates must match within tolerance
-        npt.assert_allclose(
-            cached["coords"], stats["coords"],
-            rtol=EQUIVALENCE_RTOL,
-            err_msg=f"Coordinates mismatch in {exec_mode} mode",
-        )
-
-        # Value statistics must match within tolerance
-        npt.assert_allclose(
-            cached["min"], stats["min"],
-            rtol=EQUIVALENCE_RTOL,
-            err_msg=f"Min value mismatch in {exec_mode} mode",
-        )
-        npt.assert_allclose(
-            cached["max"], stats["max"],
-            rtol=EQUIVALENCE_RTOL,
-            err_msg=f"Max value mismatch in {exec_mode} mode",
-        )
-        npt.assert_allclose(
-            cached["mean"], stats["mean"],
-            rtol=EQUIVALENCE_RTOL,
-            err_msg=f"Mean value mismatch in {exec_mode} mode",
-        )
-
+    _EQUIVALENCE_OUTPUT.write_text(json.dumps(report, indent=2))

--- a/tests/benchmarks/benchmark.py
+++ b/tests/benchmarks/benchmark.py
@@ -10,7 +10,7 @@ parsed by the CI workflow and posted as PR comments.
 
 Run locally::
 
-    pytest tests/benchmarks/benchmark.py --benchmark-only -v
+    pytest tests/benchmarks/benchmark.py -v
 
 Generate JSON for CI::
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,47 @@
+import gc
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ocsmesh import Hfun, Raster
+from ocsmesh.utils import raster_from_numpy
+
+
+@pytest.fixture(scope="module")
+def benchmark_raster_list(tmp_path_factory):
+    """Create 4 tiled rasters with 20% overlap for benchmarking.
+
+    Layout is a 2x2 grid covering [0,1] x [0,1].  Each tile spans
+    60% of each axis (50% base + 10% overlap per edge), giving 20%
+    overlap between adjacent tiles.
+
+    Scope is ``module`` so rasters are created once and shared by
+    all benchmark tests in the same file.
+    """
+
+    tdir = tmp_path_factory.mktemp("benchmark_rasters")
+
+    # 2x2 tiles with 20% overlap between neighbors
+    tile_ranges = [
+        (0.0, 0.6, 0.0, 0.6),  # top-left
+        (0.4, 1.0, 0.0, 0.6),  # top-right
+        (0.0, 0.6, 0.4, 1.0),  # bottom-left
+        (0.4, 1.0, 0.4, 1.0),  # bottom-right
+    ]
+
+    raster_list = []
+    for i, (x0, x1, y0, y1) in enumerate(tile_ranges):
+        gx, gy = np.mgrid[x0:x1:60j, y0:y1:60j]
+        dem_data = (gx * 20) - 10
+        p = tdir / f'dem_{i}.tif'
+        raster_from_numpy(p, dem_data, (gx, gy), 4326)
+        raster_list.append(Raster(p))
+
+    yield raster_list
+
+    # Cleanup
+    del raster_list
+    gc.collect()

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -16,9 +16,6 @@ def benchmark_raster_list(tmp_path_factory):
     Layout is a 2x2 grid covering [0,1] x [0,1].  Each tile spans
     60% of each axis (50% base + 10% overlap per edge), giving 20%
     overlap between adjacent tiles.
-
-    Scope is ``module`` so rasters are created once and shared by
-    all benchmark tests in the same file.
     """
 
     tdir = tmp_path_factory.mktemp("benchmark_rasters")

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,12 +1,11 @@
+"""Shared fixtures for benchmark tests."""
+
 import gc
-import shutil
-import tempfile
-from pathlib import Path
 
 import numpy as np
 import pytest
 
-from ocsmesh import Hfun, Raster
+from ocsmesh import Raster
 from ocsmesh.utils import raster_from_numpy
 
 

--- a/tests/benchmarks/generate_report.py
+++ b/tests/benchmarks/generate_report.py
@@ -1,0 +1,107 @@
+"""Generate a plain-text benchmark report from pytest-benchmark output.
+
+Reads ``output.json`` (pytest-benchmark) and ``equivalence_result.json``
+(written by ``benchmark.py``) and writes a human-readable text
+report to ``benchmark_report.txt``.
+"""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def _load_json(path):
+    """Load a JSON file, return None if missing."""
+    p = Path(path)
+    if not p.exists():
+        return None
+    return json.loads(p.read_text())
+
+
+def generate_report(benchmark_path, equivalence_path, output_path):
+    """Build the text report and write it to *output_path*."""
+
+    data = _load_json(benchmark_path)
+    if data is None:
+        print(f"ERROR: {benchmark_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    eq = _load_json(equivalence_path)
+
+    rounds = data["benchmarks"][0]["stats"]["rounds"]
+    now = datetime.now().isoformat(timespec='microseconds')
+
+    lines = []
+    lines.append("=================================================================")
+    lines.append("  Meshdata() Profiling Report")
+    lines.append("=================================================================\n")
+    lines.append(f"Date            : {now}")
+    lines.append(f"Rounds          : {rounds}\n\n")
+
+    # Timing section per mode
+    mode_stats = {}
+    for b in data["benchmarks"]:
+        name = b["name"].replace("test_meshdata_pipeline[", "").replace("]", "")
+        s = b["stats"]
+        mode_stats[name] = s
+        
+        lines.append("-----------------------------------------------------------------")
+        lines.append(f"  MODE: {name.upper()}")
+        lines.append("-----------------------------------------------------------------")
+        lines.append(f"  Time (Mean) : {s['mean']:.4f} s")
+        lines.append(f"  Min         : {s['min']:.4f} s")
+        lines.append(f"  Max         : {s['max']:.4f} s")
+        lines.append(f"  StdDev      : {s['stddev']:.4f}")
+        lines.append(f"  OPS         : {s['ops']:.4f}\n")
+
+    # Comparison
+    lines.append("=================================================================")
+    lines.append("  COMPARISON")
+    lines.append("=================================================================")
+    lines.append(f"  {'Mode':<45} {'Time'}")
+    lines.append(f"  {'-'*45} {'--------'}")
+    
+    for name, s in mode_stats.items():
+        lines.append(f"  {name:<45} {s['mean']:.2f}s")
+    lines.append("")
+
+    # Speedup (assuming baseline is first and we compare others to it)
+    if len(mode_stats) > 1:
+        baseline_name = list(mode_stats.keys())[0]
+        baseline_mean = mode_stats[baseline_name]['mean']
+        
+        for name, s in mode_stats.items():
+            if name != baseline_name:
+                speedup = baseline_mean / s['mean']
+                lines.append(f"  Speedup ({name} vs {baseline_name}):")
+                lines.append(f"    {speedup:.2f}x ({baseline_mean:.2f}s -> {s['mean']:.2f}s)\n")
+
+    # Equivalence checks
+    if eq is not None:
+        lines.append(f"  Values match ({eq['baseline']} vs others) : {eq['status'].upper()}")
+        for mode, checks in eq["comparisons"].items():
+            c = checks
+            match_str = "YES" if c["num_nodes"]["match"] else "NO"
+            lines.append(f"    {mode} node count matches : {match_str}")
+            for metric in ("min", "max", "mean"):
+                if c[metric]['rel_diff'] <= eq['rtol']:
+                    lines.append(f"    {mode} {metric:<4} matches : YES (rel diff {c[metric]['rel_diff']:.2e})")
+                else:
+                    lines.append(f"    {mode} {metric:<4} matches : NO (rel diff {c[metric]['rel_diff']:.2e})")
+    else:
+        lines.append("  Values match  : UNKNOWN (equivalence_result.json not found)")
+
+    lines.append("=================================================================\n")
+
+    report = "\n".join(lines)
+    Path(output_path).write_text(report)
+    print(f"Report written to {output_path}")
+
+
+if __name__ == "__main__":
+    generate_report(
+        benchmark_path="output.json",
+        equivalence_path="equivalence_result.json",
+        output_path="benchmark_report.txt",
+    )

--- a/tests/benchmarks/generate_report.py
+++ b/tests/benchmarks/generate_report.py
@@ -34,7 +34,7 @@ def generate_report(benchmark_path, equivalence_path, output_path):
 
     lines = []
     lines.append("=================================================================")
-    lines.append("  Meshdata() Profiling Report")
+    lines.append("  Benchmark Report")
     lines.append("=================================================================\n")
     lines.append(f"Date            : {now}")
     lines.append(f"Rounds          : {rounds}\n\n")


### PR DESCRIPTION
## Summary
This PR introduces automated performance benchmarking to compare the execution times of different processing modes (e.g., `serial` vs. `parallel`) within the `meshdata()` pipeline. The goal is to provide immediate, data-driven feedback on performance impacts during development.

### Key Features
* **Automated CI Benchmarking:** Uses `pytest-benchmark` to measure and validate execution configurations.
* **Numerical Equivalence Checks:** Ensures that all execution modes under test produce mathematically identical outputs (within tolerance) to prevent regressions.
* **Dynamic PR Reporting:** Implements a custom GitHub Actions workflow that automatically posts a detailed benchmark report directly to the PR thread.
* **In-Place Updates:** The workflow detects its own previous comments and updates them in-place on every new commit, keeping the PR thread clean while displaying the most up-to-date performance metrics for the active commit.

> **Note:** This represents the initial benchmarking infrastructure. The current test cases (`serial` and `parallel` execution of `hfun.meshdata`) serve as a baseline. The framework is designed to be easily extensible and will be expanded with more complex test cases and scenarios in the future.

## Update
We are using upload artifact to a simple .txt report for now.