### PR TITLE
refactor: mpi and enhance user script

### DIFF
--- a/ocsmesh/__init__.py
+++ b/ocsmesh/__init__.py
@@ -1,58 +1,16 @@
-import pathlib
-from importlib import util
-import tempfile
 import os
-import sys
-import platform
+import pathlib
+import tempfile
+from importlib import util
 
-# When running under MPI, pin numerical
-# library threads to 1 BEFORE numpy is imported. NumPy delegates
-# matrix operations to compiled libraries (OpenBLAS, MKL) that
-# spawn threads internally. Without pinning, each MPI rank spawns
-# N threads on an N-core node → N ranks × N threads = massive
-# oversubscription. Must happen here (before any ocsmesh submodule
-# imports numpy) to take effect.
-#
-# Detection uses environment variables that MPI launchers set
-# automatically — no mpi4py import needed at this stage.
-# TODO : review if all of these are necessary.
-_MPI_ENV_HINTS = (
-    'OMPI_COMM_WORLD_SIZE',     # Open MPI
-    'PMI_SIZE',                  # MPICH / Cray
-    'MPI_LOCALNRANKS',           # Intel MPI
-    'SLURM_NTASKS',              # SLURM (srun)
-)
-_MPI_THREAD_PIN_VARS = (
-    'OMP_NUM_THREADS',           # OpenMP (generic)
-    'MKL_NUM_THREADS',           # Intel MKL (conda numpy)
-    'OPENBLAS_NUM_THREADS',      # OpenBLAS (pip numpy)
-)
-
-# TODO: Consider another approach like a context manager.
-if any(var in os.environ for var in _MPI_ENV_HINTS):
-    # Pin numerical library threads to 1 to prevent oversubscription
-    for _var in _MPI_THREAD_PIN_VARS:
-        os.environ.setdefault(_var, '1')
-
-    # Force 'spawn' start method for multiprocessing. Under MPI,
-    # 'fork' copies the MPI communicator state into Pool children,
-    # causing deadlocks or silent corruption. Must be set here
-    # before any import triggers multiprocessing initialization.
-    import multiprocessing as _mp
-    try:
-        _mp.set_start_method('spawn', force=False)
-    except RuntimeError:
-        # Already set — check if it's safe
-        if _mp.get_start_method() != 'spawn':
-            import warnings
-            warnings.warn(
-                f"multiprocessing start method is "
-                f"'{_mp.get_start_method()}', but MPI requires "
-                f"'spawn' to avoid deadlocks. Call "
-                f"multiprocessing.set_start_method('spawn') before "
-                f"importing ocsmesh.",
-                UserWarning
-            )
+# Check if process was launched under an MPI environment (e.g., mpiexec, srun).
+# If detected, pins numerical library thread pools (OpenMP/MKL/OpenBLAS) to 1 to
+# prevent CPU thrashing and sets multiprocessing start method to 'spawn'.
+# NOTE: Must execute before any submodule imports NumPy because BLAS/MKL thread
+# pools are initialized at C-library import time.
+# NOTE: If NOT running under MPI launcher, _configure_mpi_environment is a no-op.
+from .mpi import _configure_mpi_environment
+_configure_mpi_environment()
 
 from .internal import MeshData
 from .raster import Raster
@@ -65,7 +23,7 @@ if util.find_spec("colored_traceback") is not None:
     import colored_traceback
     colored_traceback.add_hook(always=True)
 
-tmpdir = str(pathlib.Path(tempfile.gettempdir()+'/ocsmesh'))+'/'
+tmpdir = str(pathlib.Path(tempfile.gettempdir() + '/ocsmesh')) + '/'
 os.makedirs(tmpdir, exist_ok=True)
 
 __all__ = [
@@ -76,5 +34,3 @@ __all__ = [
     "MeshDriver",
     "MeshData",
 ]
-
-# mpl.rcParams['agg.path.chunksize'] = 10000

--- a/ocsmesh/__init__.py
+++ b/ocsmesh/__init__.py
@@ -12,6 +12,7 @@ from importlib import util
 from .mpi import _configure_mpi_environment
 _configure_mpi_environment()
 
+# pylint: disable=wrong-import-position
 from .internal import MeshData
 from .raster import Raster
 from .mesh import Mesh

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -2844,7 +2844,7 @@ class HfunCollector(BaseHfun):
         """MPI path for writing hfun to disk (dynamic send/recv).
 
         Same two-stage design as the parallel variant, but Stage 1 uses
-        MPIExecutor.submit() to dynamically stream tasks to idle
+        MPIExecutor.run() to dynamically stream tasks to idle
         workers via point-to-point send/recv. The existing
         _meshdata_task_worker is reused unchanged.
 
@@ -2858,7 +2858,7 @@ class HfunCollector(BaseHfun):
         Error policy: if ANY task fails, a single aggregated
         RuntimeError is raised and Stage 2 is skipped; we never
         silently emit a partial mesh built from only the surviving
-        tiles. Worker shutdown is handled by MPIExecutor.execute()'s
+        tiles. Worker shutdown is handled by MPIExecutor.run()'s
         finally block, not here.
 
         Shared-filesystem requirement: workers exchange paths to .npz

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -80,7 +80,6 @@ _logger = logging.getLogger(__name__)
 
 from ocsmesh.mpi import (
     MPIExecutor,
-    MPITaskRunner,
     _get_mpi,
     _get_mpi_comm,
     _is_mpi_active,

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -78,10 +78,10 @@ RASTER_CONSTR = (
 
 _logger = logging.getLogger(__name__)
 
+# pylint: disable=wrong-import-position
 from ocsmesh.mpi import (
     MPIExecutor,
     _get_mpi,
-    _get_mpi_comm,
     _is_mpi_active,
     _configure_mpi_environment,
 )
@@ -2511,12 +2511,12 @@ class HfunCollector(BaseHfun):
         if self.execution_mode == 'mpi':
             _logger.info("Calculate & Writing hfun to disk using MPI method.")
             return self._calculate_and_write_hfun_to_disk_mpi(out_path, **kwargs)
-        elif self.execution_mode == 'parallel' and self._nprocs > 1:
+        if self.execution_mode == 'parallel' and self._nprocs > 1:
             _logger.info("Calculate & Writing hfun to disk using PARALLEL method.")
             return self._calculate_and_write_hfun_to_disk_parallel(out_path, **kwargs)
-        else:
-            _logger.info("Calculate & Writing hfun to disk using SERIAL method.")
-            return self._calculate_and_write_hfun_to_disk_serial(out_path, **kwargs)
+
+        _logger.info("Calculate & Writing hfun to disk using SERIAL method.")
+        return self._calculate_and_write_hfun_to_disk_serial(out_path, **kwargs)
 
 
     def _calculate_and_write_hfun_to_disk_serial(

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -78,517 +78,14 @@ RASTER_CONSTR = (
 
 _logger = logging.getLogger(__name__)
 
-# TODO: review if we can make this cleaner
-# MPI support is optional
-_MPI = None
-_MPI_IMPORT_ATTEMPTED = False
-
-
-def _get_mpi():
-    """Lazy-import mpi4py.MPI. Returns the module or None."""
-    global _MPI, _MPI_IMPORT_ATTEMPTED
-    if not _MPI_IMPORT_ATTEMPTED:
-        _MPI_IMPORT_ATTEMPTED = True
-        try:
-            from mpi4py import MPI
-            _MPI = MPI
-        except ImportError:
-            pass
-    return _MPI
-
-
-def _get_mpi_comm():
-    """Return MPI.COMM_WORLD if available, else None."""
-    MPI = _get_mpi()
-    if MPI is None:
-        return None
-    return MPI.COMM_WORLD
-
-
-def _is_mpi_active():
-    """Check if we're running under an MPI launcher with >1 rank."""
-    comm = _get_mpi_comm()
-    if comm is None:
-        return False
-    try:
-        return comm.Get_size() > 1
-    except Exception:
-        return False
-
-# NOTE: multiprocessing.set_start_method('spawn') is handled in
-# ocsmesh/__init__.py (before any import can initialize the context).
-# Thread pinning (_MPI_THREAD_PIN_VARS) is also handled there.
-# The _configure_mpi_environment() function below is a fallback
-# for direct imports that bypass __init__.py.
-
-def _configure_mpi_environment():
-    # TODO: Review if this is necessary. It is a safety net for now.
-    """Safety net for MPI + numerical library thread pinning.
-
-    The primary thread pinning happens in ``ocsmesh/__init__.py``
-    (before NumPy is imported). This function serves as a fallback
-    for edge cases where collector.py is imported directly without
-    going through the package ``__init__``.
-    """
-    from ocsmesh import _MPI_THREAD_PIN_VARS
-    for var in _MPI_THREAD_PIN_VARS:
-        os.environ.setdefault(var, '1')
-
-
-class MPITaskRunner:
-    """Dynamic manager/worker MPI task runner.
-
-    Encapsulates all MPI dispatch logic. Called identically by all
-    ranks — zero rank checks in user code.
-
-    User script::
-
-        from ocsmesh.hfun.collector import MPITaskRunner
-
-        runner = MPITaskRunner()
-
-        def main():
-            hfun = Hfun(raster_list)
-            hfun.execution_mode = 'mpi'
-            return hfun.meshdata()
-
-        result = runner.run(main)  # All ranks call this
-
-    Features
-    --------
-    - Dynamic on-demand scheduling (fast ranks pull more work)
-    - Rank 0 = dedicated coordinator
-    - Soft-fail: worker exceptions → structured error dicts,
-      worker stays alive for more tasks
-    - Global excepthook prevents zombie cloud/HPC processes
-    - Individual TAG_STOP per worker (no collective shutdown)
-    - Sequential fallback when size == 1 or no MPI
-
-    Adding a new MPI operation requires:
-      1. Write a `_*_task_worker(task)` function
-      2. Register it in `MPITaskRunner._worker_registry()`: `{'my_op': _my_op_task_worker}`
-    """
-
-    # Message tags for the manager/worker protocol.
-    # Using a dict keeps them grouped and discoverable.
-    _TAGS = {
-        'TASK':   1,   # rank 0 → worker : here is a task dict
-        'RESULT': 2,   # worker → rank 0 : task succeeded (result dict)
-        'ERROR':  3,   # worker → rank 0 : task raised / structured failure
-        'STOP':   4,   # rank 0 → worker : no more work, leave the loop
-    }
-
-    @staticmethod
-    def _worker_registry():
-        """Map operation name → worker function.
-
-        Built lazily (at call time) rather than at import time so it can
-        reference worker functions defined later in this module without a
-        forward-reference NameError. Extend this dict to add new
-        MPI-enabled operations.
-        """
-        return {
-            'meshdata': _meshdata_task_worker,
-            'check_shared_fs': _check_shared_fs_task_worker,
-        }
-
-    @staticmethod
-    def install_mpi_excepthook():
-        """Override ``sys.excepthook`` to abort all MPI ranks on uncaught exception.
-
-        When an uncaught exception propagates to the top of the stack on any
-        rank, this hook writes a traceback to stderr and calls
-        ``comm.Abort(1)`` to kill ALL processes across ALL nodes immediately.
-        This prevents zombie cloud/HPC instances that keep running while
-        blocked in a ``recv()``.
-
-        Only triggers on truly uncaught exceptions; normal task failures are
-        caught by the worker loop and returned as structured error dicts.
-        """
-        MPI = _get_mpi()
-        if MPI is None:
-            return
-
-        comm = MPI.COMM_WORLD
-        rank = comm.Get_rank()
-
-        def _mpi_excepthook(exctype, value, tb):
-            sys.stderr.write(
-                f"\n[CRITICAL] Uncaught exception on Rank {rank}:\n"
-            )
-            traceback.print_exception(exctype, value, tb, file=sys.stderr)
-            sys.stderr.flush()
-            comm.Abort(1)
-
-        sys.excepthook = _mpi_excepthook
-
-    def __init__(self):
-        """Initialize MPI state and install global safety net."""
-        comm = _get_mpi_comm()
-        if comm is not None:
-            self.comm = comm
-            self.rank = comm.Get_rank()
-            self.size = comm.Get_size()
-        else:
-            self.comm = None
-            self.rank = 0
-            self.size = 1
-
-        # Install global safety net for multi-rank jobs
-        if self.comm is not None and self.size > 1:
-            self.install_mpi_excepthook()
-
-    # ── Public API ─────────────────────────────────────────────────
-
-    def run(self, user_fn):
-        """Execute user_fn on Rank 0, worker loop on all other ranks.
-
-        All ranks call this identically. Rank 0 runs *user_fn* (which
-        internally calls :meth:`dispatch` for MPI work). Workers enter
-        the recv/execute/send loop and exit when Rank 0 finishes.
-
-        Workers are always released in the ``finally`` block — even if
-        *user_fn* raises an exception.
-
-        Parameters
-        ----------
-        user_fn : callable
-            The function to run on Rank 0. Must accept no arguments.
-
-        Returns
-        -------
-        any
-            Return value of *user_fn* on Rank 0, ``None`` on workers.
-        """
-        # ── Safety check ──
-        if not callable(user_fn):
-            raise TypeError(
-                f"MPITaskRunner.run() expects a callable, "
-                f"got {type(user_fn).__name__}"
-            )
-
-        # Single rank or no MPI: just run directly
-        if self.comm is None or self.size == 1:
-            return user_fn()
-
-        if self.rank == 0:
-            try:
-                return user_fn()
-            finally:
-                # Always release workers, even on exception
-                self._shutdown_workers()
-        else:
-            self._run_worker()
-            return None
-
-    def dispatch(self, tasks):
-        """Rank-0-only: stream tasks dynamically to idle workers.
-
-        Seeds one task per worker, then refills each worker as soon as
-        it returns a result — a central work queue with on-demand
-        assignment. Returns the list of result/error dicts (order is
-        NOT the task order; use ``'original_index'`` to reassociate).
-
-        Rank 0 does not compute any task here (dedicated coordinator).
-
-        Parameters
-        ----------
-        tasks : list of dict
-            Self-describing task dicts, each with an ``'op'`` key.
-
-        Returns
-        -------
-        list of dict
-            One result (or structured error) dict per task.
-        Notes
-        -----
-        Must be called from within the callable passed to :meth:`run`.
-        Calling this method standalone without ``run()`` will cause workers
-        to hang permanently — ``run()`` is responsible for both entering
-        the worker recv loop and guaranteeing shutdown via its ``finally``
-        block.
-        """
-        # ── Safety checks ──
-        if self.comm is None:
-            raise RuntimeError("mpi4py is not available")
-        if self.rank != 0:
-            raise RuntimeError(
-                "dispatch() must only be called by Rank 0."
-            )
-        if not isinstance(tasks, list):
-            raise TypeError(
-                f"dispatch() expects a list of task dicts, "
-                f"got {type(tasks).__name__}"
-            )
-
-        # Degenerate case: no workers (size == 1)
-        # Run tasks locally so single-rank runs stay correct.
-        if self.size == 1:
-            return self._run_tasks_locally(tasks)
-
-        results = []
-        task_iter = iter(tasks)
-        inflight = 0  # tasks currently being processed by workers
-
-        # ── Seed: give each worker one task to start ──
-        for worker in range(1, self.size):
-            task = next(task_iter, None)
-            if task is None:
-                break  # fewer tasks than workers
-            self.comm.send(task, dest=worker, tag=self._TAGS['TASK'])
-            inflight += 1
-
-        # ── Refill: as each worker reports back, hand it the next ──
-        MPI = _get_mpi()
-        while inflight > 0:
-            status = MPI.Status()
-            message = self.comm.recv(
-                source=MPI.ANY_SOURCE,
-                tag=MPI.ANY_TAG,
-                status=status,
-            )
-            worker = status.Get_source()
-            inflight -= 1
-            results.append(message)
-
-            next_task = next(task_iter, None)
-            if next_task is not None:
-                self.comm.send(
-                    next_task, dest=worker, tag=self._TAGS['TASK'])
-                inflight += 1
-
-        return results
-
-    def verify_shared_filesystem(self, work_dir: Union[str, Path]):
-        """Rank 0 only: verify all workers can access and write to work_dir.
-
-        On multi-node HPC jobs, default temporary directories (like /tmp)
-        live on node-local disks. If workers are on separate physical nodes
-        from Rank 0, intermediate file operations will fail. This method
-        dispatches lightweight test tasks to confirm cross-node read visibility
-        and write permissions before any computationally expensive work begins.
-
-        Parameters
-        ----------
-        work_dir : path-like
-            The working directory path to test across all worker ranks.
-
-        Raises
-        ------
-        RuntimeError
-            If any worker rank fails to read from or write to `work_dir`.
-        """
-        if self.comm is None or self.size <= 1:
-            return
-        if self.rank != 0:
-            raise RuntimeError(
-                "verify_shared_filesystem() must only be called by Rank 0."
-            )
-
-        work_dir_str = str(work_dir)
-        pid = os.getpid()
-        _logger.info(
-            f"Verifying shared filesystem visibility across "
-            f"{self.size - 1} worker rank(s)..."
-        )
-        rank0_test_file = os.path.join(
-            work_dir_str, f".mpi_fs_check_{pid}.tmp"
-        )
-        with open(rank0_test_file, 'w') as f:
-            f.write("rank0_ok")
-
-        try:
-            check_tasks = [
-                {
-                    'op': 'check_shared_fs',
-                    'original_index': idx,
-                    'work_dir': work_dir_str,
-                    'test_read_file': rank0_test_file,
-                    'worker_rank': idx + 1,
-                }
-                for idx in range(self.size - 1)
-            ]
-            check_results = self.dispatch(check_tasks)
-        finally:
-            if os.path.exists(rank0_test_file):
-                try:
-                    os.remove(rank0_test_file)
-                except OSError:
-                    pass
-
-        check_failures = [
-            res for res in check_results
-            if not isinstance(res, dict) or res.get('status') == 'error'
-        ]
-        if check_failures:
-            first_err = (
-                check_failures[0].get('error', repr(check_failures[0]))
-                if isinstance(check_failures[0], dict)
-                else repr(check_failures[0])
-            )
-            wrk = (
-                check_failures[0].get('worker_rank', '?')
-                if isinstance(check_failures[0], dict)
-                else '?'
-            )
-            raise RuntimeError(
-                f"\n[MPI Shared Filesystem Error] Worker rank {wrk} failed "
-                f"to access or write to working directory "
-                f"'{work_dir_str}':\n  {first_err}\n\n"
-                f"On multi-node HPC/cluster jobs, intermediate files must "
-                f"be created on a shared parallel filesystem (such as "
-                f"Lustre, GPFS, or NFS) visible to all nodes, rather than "
-                f"node-local /tmp.\n\n"
-                f"--> ACTION REQUIRED: Set the TMPDIR environment variable "
-                f"to point to your shared network filesystem before "
-                f"running OCSMesh:\n"
-                f"    export TMPDIR=/scratch/$USER\n"
-                f"    # or export TMPDIR=/lustre/..."
-            )
-        _logger.info("Shared filesystem check passed across all worker ranks.")
-
-    # ── Internal ───────────────────────────────────────────────────
-
-    def _run_worker(self):
-        """Worker recv/execute/send loop (point-to-point).
-
-        Each non-zero rank calls this ONCE. The worker blocks in a
-        ``recv`` until rank 0 either hands it a task (``TAG_TASK``) or
-        tells it to stop (``TAG_STOP``). After running a task it sends
-        the result back and loops again.
-
-        A blocking ``recv`` is the correct idle-wait primitive: the
-        worker sleeps inside MPI without busy-polling and is woken only
-        when a message addressed to it arrives.
-        """
-        # ── Safety checks ──
-        if self.rank == 0:
-            raise RuntimeError(
-                "_run_worker() must only be called by worker ranks."
-            )
-
-        MPI = _get_mpi()
-        registry = self._worker_registry()
-        _logger.debug(
-            f"Rank {self.rank}: entering point-to-point worker loop"
-        )
-
-        while True:
-            # Block until rank 0 sends us something. ANY_TAG lets a
-            # single recv distinguish a task from a stop signal.
-            status = MPI.Status()
-            message = self.comm.recv(
-                source=0, tag=MPI.ANY_TAG, status=status)
-            tag = status.Get_tag()
-
-            if tag == self._TAGS['STOP']:
-                _logger.debug(
-                    f"Rank {self.rank}: received STOP, leaving loop"
-                )
-                break
-
-            if tag != self._TAGS['TASK']:
-                # Defensive: unknown control tag. Report and keep
-                # serving so a protocol slip does not silently hang.
-                _logger.warning(
-                    f"Rank {self.rank}: unexpected tag {tag!r}; "
-                    f"ignoring message"
-                )
-                continue
-
-            task = message
-            op = task.get('op') if isinstance(task, dict) else None
-            worker_fn = registry.get(op)
-
-            if worker_fn is None:
-                # Unknown operation → structured error, worker stays.
-                self.comm.send(
-                    {
-                        'status': 'error',
-                        'original_index': (
-                            task.get('original_index', -1)
-                            if isinstance(task, dict) else -1),
-                        'op': op,
-                        'worker_rank': self.rank,
-                        'error': f"No worker registered for op "
-                                 f"{op!r}",
-                        'traceback': '',
-                    },
-                    dest=0, tag=self._TAGS['ERROR'],
-                )
-                continue
-
-            try:
-                result = worker_fn(task)
-                # Some worker functions catch their own exceptions
-                # and return {'status': 'error', ...}. Route those
-                # through the error channel too.
-                if (isinstance(result, dict)
-                        and result.get('status') == 'error'):
-                    result.setdefault('worker_rank', self.rank)
-                    self.comm.send(
-                        result, dest=0, tag=self._TAGS['ERROR'])
-                else:
-                    self.comm.send(
-                        result, dest=0, tag=self._TAGS['RESULT'])
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                # Task blew up — NOT an MPI rank failure. Catch it,
-                # report it, keep the worker available for more tasks.
-                self.comm.send(
-                    {
-                        'status': 'error',
-                        'original_index': (
-                            task.get('original_index', -1)
-                            if isinstance(task, dict) else -1),
-                        'op': op,
-                        'worker_rank': self.rank,
-                        'error': repr(exc),
-                        'traceback': traceback.format_exc(),
-                    },
-                    dest=0, tag=self._TAGS['ERROR'],
-                )
-
-        _logger.debug(
-            f"Rank {self.rank}: worker loop exited cleanly"
-        )
-
-    def _shutdown_workers(self):
-        """Send TAG_STOP to each worker individually.
-
-        Individual sends (not a collective) mean each worker exits
-        independently — if one already crashed, the others still
-        receive their stop signal cleanly.
-        """
-        _logger.debug(
-            f"Rank 0: sending STOP to {self.size - 1} worker(s)"
-        )
-        for worker in range(1, self.size):
-            self.comm.send(None, dest=worker, tag=self._TAGS['STOP'])
-
-    def _run_tasks_locally(self, tasks):
-        """Fallback for single-rank: run tasks without MPI."""
-        registry = self._worker_registry()
-        results = []
-        for task in tasks:
-            fn = registry.get(task.get('op'))
-            if fn is None:
-                results.append({
-                    'status': 'error',
-                    'original_index': task.get('original_index', -1),
-                    'error': f"No worker registered for op "
-                             f"{task.get('op')!r}",
-                })
-                continue
-            try:
-                results.append(fn(task))
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                results.append({
-                    'status': 'error',
-                    'original_index': task.get('original_index', -1),
-                    'error': repr(exc),
-                    'traceback': traceback.format_exc(),
-                })
-        return results
+from ocsmesh.mpi import (
+    MPIExecutor,
+    MPITaskRunner,
+    _get_mpi,
+    _get_mpi_comm,
+    _is_mpi_active,
+    _configure_mpi_environment,
+)
 
 
 class _RefinementContourInfoCollector:
@@ -1301,52 +798,8 @@ def _meshdata_task_worker(task: dict):
         }
 
 
-def _check_shared_fs_task_worker(task: dict):
-    """Worker task that validates cross-node shared filesystem access.
-
-    Verifies that this worker rank can both read a file created by Rank 0
-    in `work_dir` (proving cross-node read visibility) and create a new
-    file in `work_dir` (proving write permissions).
-    """
-    original_index = task.get('original_index', -1)
-    work_dir = task['work_dir']
-    test_read_file = task['test_read_file']
-    worker_rank = task.get('worker_rank', -1)
-
-    try:
-        # 1. Check read visibility of Rank 0's test file
-        if not (os.path.exists(test_read_file) and os.access(test_read_file, os.R_OK)):
-            raise FileNotFoundError(
-                f"Rank {worker_rank} cannot see/read Rank 0 test file: {test_read_file}"
-            )
-
-        # 2. Check write permission by creating and removing a temporary test file
-        worker_test_file = os.path.join(
-            work_dir, f".mpi_fs_write_test_rank_{worker_rank}_{os.getpid()}.tmp"
-        )
-        with open(worker_test_file, 'w') as f:
-            f.write(f"write_ok_from_rank_{worker_rank}")
-        if os.path.exists(worker_test_file):
-            os.remove(worker_test_file)
-        else:
-            raise FileNotFoundError(
-                f"Rank {worker_rank} wrote file {worker_test_file} but cannot see it."
-            )
-
-        return {
-            'status': 'success',
-            'original_index': original_index,
-            'worker_rank': worker_rank,
-        }
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        return {
-            'status': 'error',
-            'original_index': original_index,
-            'op': task.get('op'),
-            'worker_rank': worker_rank,
-            'error': repr(e),
-            'traceback': traceback.format_exc(),
-        }
+# Register collector-specific MPI operations
+MPIExecutor.register_op('meshdata', _meshdata_task_worker)
 
 
 
@@ -1602,7 +1055,23 @@ class HfunCollector(BaseHfun):
             Arguments passed down to the underlying Hfun classes (e.g.
             mesh_engine='gmsh', stride=...).
         """
+        if self.execution_mode == 'mpi':
+            executor = MPIExecutor()
+            return executor.execute(
+                lambda: self._meshdata_mpi_pipeline(**kwargs)
+            )
 
+        return self._meshdata_pipeline(**kwargs)
+
+    def _meshdata_mpi_pipeline(self, **kwargs) -> MeshData:
+        """Full meshdata pipeline — only Rank 0 executes this.
+
+        Workers are in _run_worker() for the entire duration,
+        available for ANY executor.submit() call.
+        """
+        return self._meshdata_pipeline(**kwargs)
+
+    def _meshdata_pipeline(self, **kwargs) -> MeshData:
         # Just dummy object
         composite_hfun = MeshData([[0,0]])
 
@@ -3320,7 +2789,7 @@ class HfunCollector(BaseHfun):
         """MPI path for writing hfun to disk (dynamic send/recv).
 
         Same two-stage design as the parallel variant, but Stage 1 uses
-        MPITaskRunner.dispatch() to dynamically stream tasks to idle
+        MPIExecutor.submit() to dynamically stream tasks to idle
         workers via point-to-point send/recv. The existing
         _meshdata_task_worker is reused unchanged.
 
@@ -3334,7 +2803,7 @@ class HfunCollector(BaseHfun):
         Error policy: if ANY task fails, a single aggregated
         RuntimeError is raised and Stage 2 is skipped; we never
         silently emit a partial mesh built from only the surviving
-        tiles. Worker shutdown is handled by MPITaskRunner.run()'s
+        tiles. Worker shutdown is handled by MPIExecutor.execute()'s
         finally block, not here.
 
         Shared-filesystem requirement: workers exchange paths to .npz
@@ -3402,57 +2871,17 @@ class HfunCollector(BaseHfun):
             tasks.append(task)
 
         # ── Dynamic point-to-point dispatch (Rank 0 only) ──
-        # Workers are in MPITaskRunner._run_worker() — they receive
+        # Workers are in MPIExecutor._run_worker() — they receive
         # tasks individually via recv() and return results via send().
-        # Shutdown is handled by runner.run()'s finally block.
+        # Shutdown is handled by executor.execute()'s finally block.
 
-        #TODO: All the MPI code to be refactored and reused between all MPI method.
-        runner = MPITaskRunner()
-
-        # ── Pre-flight validation: verify shared filesystem across ranks ──
-        runner.verify_shared_filesystem(self._work_dir)
-
-        _logger.info(
-            f"Stage 1 (MPI/dynamic): streaming {len(tasks)} meshdata() "
-            f"tasks to {max(runner.size - 1, 1)} worker rank(s)"
+        executor = MPIExecutor()
+        raw_results = executor.submit(
+            tasks, work_dir=self._work_dir, fail_fast=True
         )
-
-        results = runner.dispatch(tasks)
-        _logger.info("Stage 1 (MPI/dynamic): all meshdata() tasks returned.")
-
-        # ── Aggregate results & enforce fail-fast error policy ──
-        stage1_results = {}
-        failures = []
-        for result in results:
-            if not isinstance(result, dict) or result.get('status') == 'error':
-                failures.append(result)
-                idx = (result.get('original_index', -1)
-                       if isinstance(result, dict) else -1)
-                err = (result.get('error') if isinstance(result, dict)
-                       else repr(result))
-                wrk = (result.get('worker_rank', '?')
-                       if isinstance(result, dict) else '?')
-                _logger.error(
-                    f"meshdata task failed for loop index {idx} "
-                    f"(worker rank {wrk}): {err}"
-                )
-                continue
-            stage1_results[result['original_index']] = result['output_path']
-
-        if failures:
-            # Do NOT proceed to Stage 2 with a partial result set —
-            # that would produce a mesh silently missing tiles.
-            summary = "; ".join(
-                f"idx={f.get('original_index', -1)} "
-                f"rank={f.get('worker_rank', '?')} "
-                f"err={f.get('error', 'unknown')}"
-                for f in failures if isinstance(f, dict)
-            )
-            raise RuntimeError(
-                f"{len(failures)} of {len(tasks)} MPI meshdata task(s) "
-                f"failed; aborting without writing output. "
-                f"Details: {summary}"
-            )
+        stage1_results = {
+            idx: res['output_path'] for idx, res in raw_results.items()
+        }
 
         # ========== STAGE 2: SEQUENTIAL overlap clip + write ==========
         # Identical to the parallel variant.

--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -83,6 +83,7 @@ from ocsmesh.mpi import (
     MPIExecutor,
     _get_mpi,
     _is_mpi_active,
+    _is_mpi_env_detected,
     _configure_mpi_environment,
 )
 
@@ -1055,20 +1056,65 @@ class HfunCollector(BaseHfun):
             mesh_engine='gmsh', stride=...).
         """
         if self.execution_mode == 'mpi':
-            executor = MPIExecutor()
-            return executor.execute(
-                lambda: self._meshdata_mpi_pipeline(**kwargs)
-            )
+            return self._meshdata_mpi_pipeline(**kwargs)
 
         return self._meshdata_pipeline(**kwargs)
 
     def _meshdata_mpi_pipeline(self, **kwargs) -> MeshData:
-        """Full meshdata pipeline — only Rank 0 executes this.
+        """Full meshdata pipeline — all ranks call collectively.
 
-        Workers are in _run_worker() for the entire duration,
-        available for ANY executor.submit() call.
+        Only MPIExecutor.run() is collective (all ranks participate).
+        All other stages are rank-0-only for now, with comments marking
+        future MPI candidates. Workers skip straight to the run() call,
+        then return None.
         """
-        return self._meshdata_pipeline(**kwargs)
+        is_manager = MPIExecutor.is_manager()
+
+        if self._method == 'exact':
+            # TODO(mpi): _apply_features could be distributed in the
+            # future (each rank applies features to a subset of hfuns).
+            # For now, rank 0 only.
+            if is_manager:
+                self._apply_features()
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # ── COLLECTIVE: all ranks participate here ──
+                # MPIExecutor.run() inside this call handles the
+                # rank split (rank 0 dispatches, workers recv).
+                hfun_path_list = self._calculate_and_write_hfun_to_disk(
+                    temp_dir, **kwargs
+                )
+
+                # Workers got [] from run() — nothing left to do.
+                if not hfun_path_list:
+                    return None
+
+                # TODO(mpi): _get_hfun_composite reads .2dm files and
+                # vstacks coordinates. Could be distributed in the future.
+                # For now, rank 0 only.
+                composite_hfun = self._get_hfun_composite(hfun_path_list)
+
+        elif self._method == 'fast':
+            # TODO(mpi): fast method not yet MPI-enabled.
+            # For now, rank 0 only. Workers return None.
+            if not is_manager:
+                return None
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                rast = self._create_big_raster(temp_dir)
+                hfun = self._apply_features_fast(rast)
+                composite_hfun = self._get_hfun_composite_fast(
+                    hfun, **kwargs
+                )
+                del rast
+                del hfun
+
+        else:
+            raise ValueError(
+                f"Invalid method specified: {self._method}"
+            )
+
+        return composite_hfun
 
     def _meshdata_pipeline(self, **kwargs) -> MeshData:
         # Just dummy object
@@ -2056,7 +2102,16 @@ class HfunCollector(BaseHfun):
             )
 
         if mode == 'mpi':
-            if _get_mpi() is None:
+            if not _is_mpi_env_detected():
+                # Not running under mpiexec/srun — can't use MPI.
+                warnings.warn(
+                    "MPI mode requested but no MPI environment detected "
+                    "(no mpiexec/srun). Falling back to 'parallel' mode.",
+                    UserWarning
+                )
+                mode = 'parallel'
+            elif _get_mpi() is None:
+                # Under MPI launcher but mpi4py not installed.
                 warnings.warn(
                     "mpi4py is not installed. Falling back to 'parallel' "
                     "mode. Install mpi4py for MPI support: "
@@ -2065,8 +2120,9 @@ class HfunCollector(BaseHfun):
                 )
                 mode = 'parallel'
             elif not _is_mpi_active():
+                # mpi4py available but only 1 rank — pointless.
                 warnings.warn(
-                    "MPI mode requested but no MPI environment detected. "
+                    "MPI mode requested but only 1 rank detected. "
                     "Falling back to 'parallel' mode.",
                     UserWarning
                 )
@@ -2869,15 +2925,19 @@ class HfunCollector(BaseHfun):
                 }
             tasks.append(task)
 
-        # ── Dynamic point-to-point dispatch (Rank 0 only) ──
-        # Workers are in MPIExecutor._run_worker() — they receive
-        # tasks individually via recv() and return results via send().
-        # Shutdown is handled by executor.execute()'s finally block.
-
-        executor = MPIExecutor()
-        raw_results = executor.submit(
+        # ── Collective dispatch via MPIExecutor.run() ──
+        # All ranks reach here with the same task list.
+        # Inside run(): rank 0 dispatches tasks to workers,
+        # workers enter recv loop. Returns results on rank 0,
+        # None on workers.
+        raw_results = MPIExecutor.run(
             tasks, work_dir=self._work_dir, fail_fast=True
         )
+
+        # Workers get None from run() — nothing left for them to do.
+        if raw_results is None:
+            return []
+
         stage1_results = {
             idx: res['output_path'] for idx, res in raw_results.items()
         }

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -250,6 +250,19 @@ class MPIExecutor:
         if self.comm is not None and self.size > 1:
             self.install_mpi_excepthook()
 
+    # ── Rank Queries ──────────────────────────────────────────────
+
+    @classmethod
+    def is_manager(cls):
+        """Return True if this process is rank 0 (or not running under MPI).
+
+        Convenience check so callers don't need to instantiate the
+        singleton just to inspect rank. Safe to call from any context:
+        returns True when MPI is not active (serial fallback).
+        """
+        instance = cls()
+        return instance.rank == 0
+
     # ── Registration ──────────────────────────────────────────────
 
     @classmethod
@@ -321,6 +334,44 @@ class MPIExecutor:
         sys.excepthook = _mpi_excepthook
 
     # ── Public API ────────────────────────────────────────────────
+
+    @classmethod
+    def run(cls, tasks, work_dir=None, fail_fast=True):
+        """All ranks call collectively. Dispatch tasks, return results.
+
+        Single-call entry point that merges :meth:`execute` and
+        :meth:`submit`. Starts a worker session, dispatches all tasks,
+        shuts workers down, and returns aggregated results on Rank 0
+        (``None`` on workers).
+
+        Design note: all ranks execute the calling code *before* this
+        method is reached. This is intentional — it keeps every rank
+        available for future MPI work in pre-dispatch stages (e.g.
+        distributed task building, parallel feature application).
+        The ``execute()`` pattern locks workers into a recv loop early,
+        preventing this.
+
+        Parameters
+        ----------
+        tasks : list of dict
+            Task dicts, each with ``'op'`` and ``'original_index'`` keys.
+        work_dir : path-like or None, default=None
+            If provided, verify shared filesystem before dispatching.
+        fail_fast : bool, default=True
+            Stop sending new tasks on first error.
+
+        Returns
+        -------
+        dict or None
+            ``{original_index: result_dict}`` on Rank 0; ``None`` on
+            worker ranks.
+        """
+        instance = cls()
+        return instance.execute(
+            lambda: instance.submit(
+                tasks, work_dir=work_dir, fail_fast=fail_fast
+            )
+        )
 
     def execute(self, pipeline_fn):
         """Execute pipeline_fn on Rank 0, worker loop on all other ranks.

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -52,8 +52,15 @@ def _get_mpi():
     return _MPI
 
 
+def _is_mpi_env_detected():
+    """Check if environment variables indicate an MPI launcher (mpiexec, srun, etc.)."""
+    return any(var in os.environ for var in _MPI_ENV_HINTS)
+
+
 def _get_mpi_comm():
-    """Return MPI.COMM_WORLD if available, else None."""
+    """Return MPI.COMM_WORLD if running under an MPI launcher and mpi4py is available, else None."""
+    if not _is_mpi_env_detected():
+        return None
     MPI = _get_mpi()
     if MPI is None:
         return None
@@ -92,7 +99,7 @@ def _configure_mpi_environment():
     and sets the multiprocessing start method to 'spawn' to avoid fork
     deadlocks with open MPI communicators.
     """
-    if any(var in os.environ for var in _MPI_ENV_HINTS):
+    if _is_mpi_env_detected():
         for var in _MPI_THREAD_PIN_VARS:
             os.environ.setdefault(var, '1')
 
@@ -175,7 +182,7 @@ class MPIExecutor:
 
     Usage inside a collector::
 
-        executor = MPIExecutor()  # Singleton — always the same instance
+        executor = MPIExecutor()  # always returns the Singleton
         return executor.execute(
             lambda: self._my_pipeline_mpi(executor, **kwargs)
         )
@@ -204,6 +211,9 @@ class MPIExecutor:
     """
 
     _instance = None
+    _registered_ops = {
+        'check_shared_fs': _check_shared_fs_task_worker,
+    }
 
     # Message tags for the manager/worker protocol.
     # Using a dict keeps them grouped and discoverable.
@@ -236,11 +246,6 @@ class MPIExecutor:
             self.rank = 0
             self.size = 1
 
-        # Built-in ops (generic, not collector-specific)
-        self._worker_ops = {
-            'check_shared_fs': _check_shared_fs_task_worker,
-        }
-
         # Install global safety net for multi-rank jobs
         if self.comm is not None and self.size > 1:
             self.install_mpi_excepthook()
@@ -261,12 +266,11 @@ class MPIExecutor:
         fn : callable
             Worker function: ``fn(task_dict) -> result_dict``.
         """
-        instance = cls()  # triggers Singleton creation if needed
-        instance._worker_ops[name] = fn
+        cls._registered_ops[name] = fn
 
     def _worker_registry(self):
         """Return the current operation -> function mapping."""
-        return dict(self._worker_ops)
+        return dict(self._registered_ops)
 
     # ── Global Safety Net ─────────────────────────────────────────
 

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -36,6 +36,17 @@ _logger = logging.getLogger(__name__)
 
 _MPI = None
 _MPI_IMPORT_ATTEMPTED = False
+_MPI_ENV_HINTS = (
+    'OMPI_COMM_WORLD_SIZE',     # Open MPI
+    'PMI_SIZE',                  # MPICH / Cray
+    'MPI_LOCALNRANKS',           # Intel MPI
+    'SLURM_NTASKS',              # SLURM (srun)
+)
+_MPI_THREAD_PIN_VARS = (
+    'OMP_NUM_THREADS',           # OpenMP (generic)
+    'MKL_NUM_THREADS',           # Intel MKL (conda numpy)
+    'OPENBLAS_NUM_THREADS',      # OpenBLAS (pip numpy)
+)
 
 
 def _get_mpi():
@@ -75,19 +86,6 @@ def _is_mpi_active():
         return comm.Get_size() > 1
     except Exception:  # pylint: disable=broad-exception-caught
         return False
-
-
-_MPI_ENV_HINTS = (
-    'OMPI_COMM_WORLD_SIZE',     # Open MPI
-    'PMI_SIZE',                  # MPICH / Cray
-    'MPI_LOCALNRANKS',           # Intel MPI
-    'SLURM_NTASKS',              # SLURM (srun)
-)
-_MPI_THREAD_PIN_VARS = (
-    'OMP_NUM_THREADS',           # OpenMP (generic)
-    'MKL_NUM_THREADS',           # Intel MKL (conda numpy)
-    'OPENBLAS_NUM_THREADS',      # OpenBLAS (pip numpy)
-)
 
 
 def _configure_mpi_environment():

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -25,10 +25,11 @@ import logging
 import os
 import sys
 import traceback
-from pathlib import Path
-from typing import Union
+import traceback
 
 _logger = logging.getLogger(__name__)
+
+# pylint: disable=c-extension-no-member,import-outside-toplevel
 
 # ── MPI lazy import ────────────────────────────────────────────────
 # mpi4py is an optional dependency. These helpers let the rest of
@@ -40,7 +41,7 @@ _MPI_IMPORT_ATTEMPTED = False
 
 def _get_mpi():
     """Lazy-import mpi4py.MPI. Returns the module or None."""
-    global _MPI, _MPI_IMPORT_ATTEMPTED
+    global _MPI, _MPI_IMPORT_ATTEMPTED  # pylint: disable=global-statement
     if not _MPI_IMPORT_ATTEMPTED:
         _MPI_IMPORT_ATTEMPTED = True
         try:
@@ -66,7 +67,7 @@ def _is_mpi_active():
         return False
     try:
         return comm.Get_size() > 1
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         return False
 
 
@@ -221,7 +222,7 @@ class MPIExecutor:
 
     def __init__(self):
         """Initialize MPI state and install global safety net."""
-        if self._initialized:
+        if getattr(self, '_initialized', False):
             return
         self._initialized = True
 
@@ -312,7 +313,7 @@ class MPIExecutor:
                 pass
             comm.Abort(1)
 
-        _mpi_excepthook._is_mpi_hook = True  # for idempotency
+        _mpi_excepthook._is_mpi_hook = True  # pylint: disable=protected-access,attribute-defined-outside-init
         sys.excepthook = _mpi_excepthook
 
     # ── Public API ────────────────────────────────────────────────
@@ -756,4 +757,3 @@ class MPIExecutor:
                     'traceback': traceback.format_exc(),
                 })
         return results
-

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -11,11 +11,12 @@ Typical collector usage::
     # Register domain-specific worker functions at import time
     MPIExecutor.register_op('meshdata', _meshdata_task_worker)
 
-    # Inside the collector method:
-    executor = MPIExecutor()  # always returns the Singleton
-    result = executor.execute(
-        lambda: self._pipeline_mpi(executor, **kwargs)
-    )
+    # Inside the collector method (all ranks call collectively):
+    results = MPIExecutor.run(tasks, work_dir=self._work_dir)
+
+``run()`` is the only public entry point for dispatching tasks.
+``_execute()`` and ``_submit()`` are private — calling them directly
+bypasses the worker recv loop setup and causes deadlocks.
 
 Users never interact with this module directly. They simply set
 ``hfun.execution_mode = 'mpi'`` and call ``hfun.meshdata()``.
@@ -179,15 +180,14 @@ class MPIExecutor:
 
     Usage inside a collector::
 
-        executor = MPIExecutor()  # always returns the Singleton
-        return executor.execute(
-            lambda: self._my_pipeline_mpi(executor, **kwargs)
+        results = MPIExecutor.run(
+            tasks, work_dir=self._work_dir
         )
 
-    Inside the pipeline function, call :meth:`submit` one or more
-    times to dispatch batches of tasks to idle workers::
-
-        results = executor.submit(tasks, work_dir=self._work_dir)
+    ``run()`` is the only public entry point for dispatching tasks.
+    ``_execute()`` and ``_submit()`` are private — calling them
+    directly bypasses the worker recv loop setup, which caused
+    deadlocks (see PR review Issue #1 and #2).
 
     Features
     --------
@@ -336,17 +336,15 @@ class MPIExecutor:
     def run(cls, tasks, work_dir=None, fail_fast=True):
         """All ranks call collectively. Dispatch tasks, return results.
 
-        Single-call entry point that merges :meth:`execute` and
-        :meth:`submit`. Starts a worker session, dispatches all tasks,
-        shuts workers down, and returns aggregated results on Rank 0
-        (``None`` on workers).
+        Single-call entry point — the only public way to dispatch MPI
+        tasks. Internally calls ``_execute()`` + ``_submit()``, which
+        are private to prevent misuse (calling them directly bypasses
+        worker recv loop setup and causes deadlocks).
 
         Design note: all ranks execute the calling code *before* this
         method is reached. This is intentional — it keeps every rank
         available for future MPI work in pre-dispatch stages (e.g.
         distributed task building, parallel feature application).
-        The ``execute()`` pattern locks workers into a recv loop early,
-        preventing this.
 
         Parameters
         ----------
@@ -364,14 +362,18 @@ class MPIExecutor:
             worker ranks.
         """
         instance = cls()
-        return instance.execute(
-            lambda: instance.submit(
+        return instance._execute(
+            lambda: instance._submit(
                 tasks, work_dir=work_dir, fail_fast=fail_fast
             )
         )
 
-    def execute(self, pipeline_fn):
+    def _execute(self, pipeline_fn):
         """Execute pipeline_fn on Rank 0, worker loop on all other ranks.
+
+        Private — must only be called via :meth:`run`. Calling directly
+        requires the caller to guarantee workers enter this method
+        collectively, which is error-prone and caused deadlocks
 
         All ranks must call this collectively.  Rank 0 runs
         ``pipeline_fn()`` inside a try/finally that guarantees
@@ -379,16 +381,11 @@ class MPIExecutor:
         or exception.  Workers enter :meth:`_run_worker` and block
         until they receive ``TAG_STOP``.
 
-        Workers remain alive for the entire duration of ``pipeline_fn``,
-        available for multiple :meth:`submit` calls. This allows a
-        pipeline to distribute different operations (meshdata, features,
-        contours, etc.) across the same worker pool in sequence.
-
         Parameters
         ----------
         pipeline_fn : callable
             A zero-argument callable that contains the Rank-0-only
-            pipeline logic. Must call :meth:`submit` for distributed
+            pipeline logic. Must call :meth:`_submit` for distributed
             work. The return value is passed through on Rank 0.
 
         Returns
@@ -402,7 +399,7 @@ class MPIExecutor:
             if callable(pipeline_fn):
                 return pipeline_fn()
             raise TypeError(
-                f"MPIExecutor.execute() expects a callable, "
+                f"MPIExecutor._execute() expects a callable, "
                 f"got {type(pipeline_fn).__name__}"
             )
 
@@ -415,12 +412,13 @@ class MPIExecutor:
             self._run_worker()
             return None
 
-    def submit(self, tasks, work_dir=None, fail_fast=True):
+    def _submit(self, tasks, work_dir=None, fail_fast=True):
         """Verify filesystem, dispatch tasks, aggregate results, raise on failure.
 
-        This is the main entry point for collectors to run distributed
-        tasks. Encapsulates the full lifecycle: pre-flight filesystem
-        check -> dynamic dispatch -> result aggregation -> error reporting.
+        Private — must only be called from within ``_execute()``'s
+        pipeline_fn. Calling outside ``_execute()`` means workers
+        are not in their recv loop, and ``_dispatch()`` will deadlock
+
 
         Parameters
         ----------

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -25,7 +25,6 @@ import logging
 import os
 import sys
 import traceback
-import traceback
 
 _logger = logging.getLogger(__name__)
 

--- a/ocsmesh/mpi.py
+++ b/ocsmesh/mpi.py
@@ -1,0 +1,759 @@
+"""MPI infrastructure for OCSMesh.
+
+Provides :class:`MPIExecutor` — a Singleton manager/worker coordinator
+that any collector (HfunCollector, GeomCollector, etc.) can use for
+distributed task execution on HPC clusters.
+
+Typical collector usage::
+
+    from ocsmesh.mpi import MPIExecutor
+
+    # Register domain-specific worker functions at import time
+    MPIExecutor.register_op('meshdata', _meshdata_task_worker)
+
+    # Inside the collector method:
+    executor = MPIExecutor()  # always returns the Singleton
+    result = executor.execute(
+        lambda: self._pipeline_mpi(executor, **kwargs)
+    )
+
+Users never interact with this module directly. They simply set
+``hfun.execution_mode = 'mpi'`` and call ``hfun.meshdata()``.
+"""
+
+import logging
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Union
+
+_logger = logging.getLogger(__name__)
+
+# ── MPI lazy import ────────────────────────────────────────────────
+# mpi4py is an optional dependency. These helpers let the rest of
+# the module work without it (graceful fallback to serial).
+
+_MPI = None
+_MPI_IMPORT_ATTEMPTED = False
+
+
+def _get_mpi():
+    """Lazy-import mpi4py.MPI. Returns the module or None."""
+    global _MPI, _MPI_IMPORT_ATTEMPTED
+    if not _MPI_IMPORT_ATTEMPTED:
+        _MPI_IMPORT_ATTEMPTED = True
+        try:
+            from mpi4py import MPI
+            _MPI = MPI
+        except ImportError:
+            pass
+    return _MPI
+
+
+def _get_mpi_comm():
+    """Return MPI.COMM_WORLD if available, else None."""
+    MPI = _get_mpi()
+    if MPI is None:
+        return None
+    return MPI.COMM_WORLD
+
+
+def _is_mpi_active():
+    """Check if we're running under an MPI launcher with >1 rank."""
+    comm = _get_mpi_comm()
+    if comm is None:
+        return False
+    try:
+        return comm.Get_size() > 1
+    except Exception:
+        return False
+
+
+_MPI_ENV_HINTS = (
+    'OMPI_COMM_WORLD_SIZE',     # Open MPI
+    'PMI_SIZE',                  # MPICH / Cray
+    'MPI_LOCALNRANKS',           # Intel MPI
+    'SLURM_NTASKS',              # SLURM (srun)
+)
+_MPI_THREAD_PIN_VARS = (
+    'OMP_NUM_THREADS',           # OpenMP (generic)
+    'MKL_NUM_THREADS',           # Intel MKL (conda numpy)
+    'OPENBLAS_NUM_THREADS',      # OpenBLAS (pip numpy)
+)
+
+
+def _configure_mpi_environment():
+    """Safety net for MPI environment, thread pinning, and multiprocessing.
+
+    Pins numerical library threads (OpenMP/MKL/OpenBLAS) to 1 to prevent
+    thread oversubscription when multiple MPI ranks run on the same node,
+    and sets the multiprocessing start method to 'spawn' to avoid fork
+    deadlocks with open MPI communicators.
+    """
+    if any(var in os.environ for var in _MPI_ENV_HINTS):
+        for var in _MPI_THREAD_PIN_VARS:
+            os.environ.setdefault(var, '1')
+
+        import multiprocessing as mp
+        try:
+            mp.set_start_method('spawn', force=False)
+        except RuntimeError:
+            if mp.get_start_method() != 'spawn':
+                import warnings
+                warnings.warn(
+                    f"multiprocessing start method is '{mp.get_start_method()}', "
+                    f"but MPI requires 'spawn' to avoid deadlocks. Call "
+                    f"multiprocessing.set_start_method('spawn') before "
+                    f"importing ocsmesh.",
+                    UserWarning
+                )
+
+
+# ── Generic worker functions ──────────────────────────────────────
+
+def _check_shared_fs_task_worker(task: dict):
+    """Worker task that validates cross-node shared filesystem access.
+
+    Verifies that this worker rank can both read a file created by Rank 0
+    in ``work_dir`` (proving cross-node read visibility) and create a new
+    file in ``work_dir`` (proving write permissions).
+    """
+    original_index = task.get('original_index', -1)
+    work_dir = task['work_dir']
+    test_read_file = task['test_read_file']
+    worker_rank = task.get('worker_rank', -1)
+
+    try:
+        # 1. Check read visibility of Rank 0's test file
+        if not (os.path.exists(test_read_file)
+                and os.access(test_read_file, os.R_OK)):
+            raise FileNotFoundError(
+                f"Rank {worker_rank} cannot see/read Rank 0 test file: "
+                f"{test_read_file}"
+            )
+
+        # 2. Check write permission by creating and removing a test file
+        worker_test_file = os.path.join(
+            work_dir,
+            f".mpi_fs_write_test_rank_{worker_rank}_{os.getpid()}.tmp"
+        )
+        with open(worker_test_file, 'w') as f:
+            f.write(f"write_ok_from_rank_{worker_rank}")
+        if os.path.exists(worker_test_file):
+            os.remove(worker_test_file)
+        else:
+            raise FileNotFoundError(
+                f"Rank {worker_rank} wrote file {worker_test_file} "
+                f"but cannot see it."
+            )
+
+        return {
+            'status': 'success',
+            'original_index': original_index,
+            'worker_rank': worker_rank,
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return {
+            'status': 'error',
+            'original_index': original_index,
+            'op': task.get('op'),
+            'worker_rank': worker_rank,
+            'error': repr(e),
+            'traceback': traceback.format_exc(),
+        }
+
+
+# ── MPIExecutor ───────────────────────────────────────────────────
+
+class MPIExecutor:
+    """Singleton MPI manager/worker coordinator.
+
+    Encapsulates all MPI dispatch logic. Any OCSMesh collector can
+    use this executor for distributed task execution.
+
+    Usage inside a collector::
+
+        executor = MPIExecutor()  # Singleton — always the same instance
+        return executor.execute(
+            lambda: self._my_pipeline_mpi(executor, **kwargs)
+        )
+
+    Inside the pipeline function, call :meth:`submit` one or more
+    times to dispatch batches of tasks to idle workers::
+
+        results = executor.submit(tasks, work_dir=self._work_dir)
+
+    Features
+    --------
+    - Singleton: one instance per process, shared across all collectors
+    - Extensible: collectors register ops via :meth:`register_op`
+    - Dynamic on-demand scheduling (fast ranks pull more work)
+    - Rank 0 = dedicated coordinator
+    - Soft-fail: worker exceptions -> structured error dicts,
+      worker stays alive for more tasks
+    - Global excepthook prevents zombie cloud/HPC processes
+    - Individual TAG_STOP per worker (no collective shutdown)
+    - Sequential fallback when size == 1 or no MPI
+    - Fail-fast dispatch: stop sending new tasks on first error
+
+    Adding a new MPI operation requires:
+      1. Write a ``_*_task_worker(task)`` function
+      2. Register it: ``MPIExecutor.register_op('my_op', _my_op_worker)``
+    """
+
+    _instance = None
+
+    # Message tags for the manager/worker protocol.
+    # Using a dict keeps them grouped and discoverable.
+    _TAGS = {
+        'TASK':   1,   # rank 0 -> worker : here is a task dict
+        'RESULT': 2,   # worker -> rank 0 : task succeeded (result dict)
+        'ERROR':  3,   # worker -> rank 0 : task raised / structured failure
+        'STOP':   4,   # rank 0 -> worker : no more work, leave the loop
+    }
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        """Initialize MPI state and install global safety net."""
+        if self._initialized:
+            return
+        self._initialized = True
+
+        comm = _get_mpi_comm()
+        if comm is not None:
+            self.comm = comm
+            self.rank = comm.Get_rank()
+            self.size = comm.Get_size()
+        else:
+            self.comm = None
+            self.rank = 0
+            self.size = 1
+
+        # Built-in ops (generic, not collector-specific)
+        self._worker_ops = {
+            'check_shared_fs': _check_shared_fs_task_worker,
+        }
+
+        # Install global safety net for multi-rank jobs
+        if self.comm is not None and self.size > 1:
+            self.install_mpi_excepthook()
+
+    # ── Registration ──────────────────────────────────────────────
+
+    @classmethod
+    def register_op(cls, name, fn):
+        """Register a worker function for the given operation name.
+
+        Collectors call this at module load time to make their
+        domain-specific worker functions available to the executor.
+
+        Parameters
+        ----------
+        name : str
+            Operation name (matches the ``'op'`` key in task dicts).
+        fn : callable
+            Worker function: ``fn(task_dict) -> result_dict``.
+        """
+        instance = cls()  # triggers Singleton creation if needed
+        instance._worker_ops[name] = fn
+
+    def _worker_registry(self):
+        """Return the current operation -> function mapping."""
+        return dict(self._worker_ops)
+
+    # ── Global Safety Net ─────────────────────────────────────────
+
+    @staticmethod
+    def install_mpi_excepthook():
+        """Install an MPI-aware ``sys.excepthook`` that aborts all ranks.
+
+        When an uncaught exception propagates to the top of the stack on any
+        rank, this hook writes a traceback to stderr, chains to the
+        **previous** excepthook (so logging frameworks / debuggers still
+        fire), and then calls ``comm.Abort(1)`` to kill ALL processes
+        across ALL nodes immediately.  This prevents zombie cloud/HPC
+        instances that keep running while blocked in a ``recv()``.
+
+        The hook is installed **at most once** (idempotent).  Calling
+        this method again after it has already been installed is a no-op.
+
+        Only triggers on truly uncaught exceptions; normal task failures
+        are caught by the worker loop and returned as structured error
+        dicts.
+        """
+        # Idempotency guard.
+        if getattr(sys.excepthook, '_is_mpi_hook', False):
+            return
+
+        MPI = _get_mpi()
+        if MPI is None:
+            return
+
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        _previous_hook = sys.excepthook
+
+        def _mpi_excepthook(exctype, value, tb):
+            sys.stderr.write(
+                f"\n[CRITICAL] Uncaught exception on Rank {rank}:\n"
+            )
+            traceback.print_exception(exctype, value, tb, file=sys.stderr)
+            sys.stderr.flush()
+            # Chain to previous hook
+            try:
+                _previous_hook(exctype, value, tb)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+            comm.Abort(1)
+
+        _mpi_excepthook._is_mpi_hook = True  # for idempotency
+        sys.excepthook = _mpi_excepthook
+
+    # ── Public API ────────────────────────────────────────────────
+
+    def execute(self, pipeline_fn):
+        """Execute pipeline_fn on Rank 0, worker loop on all other ranks.
+
+        All ranks must call this collectively.  Rank 0 runs
+        ``pipeline_fn()`` inside a try/finally that guarantees
+        ``TAG_STOP`` is sent to every worker, regardless of success
+        or exception.  Workers enter :meth:`_run_worker` and block
+        until they receive ``TAG_STOP``.
+
+        Workers remain alive for the entire duration of ``pipeline_fn``,
+        available for multiple :meth:`submit` calls. This allows a
+        pipeline to distribute different operations (meshdata, features,
+        contours, etc.) across the same worker pool in sequence.
+
+        Parameters
+        ----------
+        pipeline_fn : callable
+            A zero-argument callable that contains the Rank-0-only
+            pipeline logic. Must call :meth:`submit` for distributed
+            work. The return value is passed through on Rank 0.
+
+        Returns
+        -------
+        object or None
+            Return value of ``pipeline_fn()`` on Rank 0; ``None`` on
+            all worker ranks.
+        """
+        # Non-MPI fallback: just run the callable directly.
+        if self.comm is None or self.size == 1:
+            if callable(pipeline_fn):
+                return pipeline_fn()
+            raise TypeError(
+                f"MPIExecutor.execute() expects a callable, "
+                f"got {type(pipeline_fn).__name__}"
+            )
+
+        if self.rank == 0:
+            try:
+                return pipeline_fn()
+            finally:
+                self._shutdown_workers()
+        else:
+            self._run_worker()
+            return None
+
+    def submit(self, tasks, work_dir=None, fail_fast=True):
+        """Verify filesystem, dispatch tasks, aggregate results, raise on failure.
+
+        This is the main entry point for collectors to run distributed
+        tasks. Encapsulates the full lifecycle: pre-flight filesystem
+        check -> dynamic dispatch -> result aggregation -> error reporting.
+
+        Parameters
+        ----------
+        tasks : list of dict
+            Task dicts, each with an ``'op'`` key matching a registered
+            worker function and an ``'original_index'`` key for result
+            reassociation.
+        work_dir : path-like or None, default=None
+            If provided, run :meth:`verify_shared_filesystem` before
+            dispatching to ensure all workers can read/write this path.
+        fail_fast : bool, default=True
+            Stop dispatching new tasks on first error. In-flight tasks
+            (already being computed) are still drained and their results
+            collected.
+
+        Returns
+        -------
+        dict
+            Mapping of ``{original_index: result_dict}`` for successes
+            only.
+
+        Raises
+        ------
+        RuntimeError
+            If any task failed, with a summary of all failures.
+        """
+        if work_dir is not None:
+            self.verify_shared_filesystem(work_dir)
+
+        _logger.info(
+            f"Dispatching {len(tasks)} task(s) to "
+            f"{max(self.size - 1, 1)} worker(s)"
+        )
+        results = self._dispatch(tasks, fail_fast=fail_fast)
+        _logger.info("All dispatched tasks returned.")
+
+        successes = {}
+        failures = []
+        for result in results:
+            if not isinstance(result, dict) or result.get('status') == 'error':
+                failures.append(result)
+                idx = (result.get('original_index', -1)
+                       if isinstance(result, dict) else -1)
+                err = (result.get('error') if isinstance(result, dict)
+                       else repr(result))
+                wrk = (result.get('worker_rank', '?')
+                       if isinstance(result, dict) else '?')
+                _logger.error(
+                    f"MPI task failed for index {idx} "
+                    f"(worker rank {wrk}): {err}"
+                )
+            else:
+                successes[result['original_index']] = result
+
+        if failures:
+            summary = "; ".join(
+                f"idx={f.get('original_index', -1)} "
+                f"rank={f.get('worker_rank', '?')} "
+                f"err={f.get('error', 'unknown')}"
+                for f in failures if isinstance(f, dict)
+            )
+            raise RuntimeError(
+                f"{len(failures)} of {len(results)} dispatched MPI "
+                f"task(s) failed ({len(tasks)} total); "
+                f"aborting. Details: {summary}"
+            )
+
+        return successes
+
+    def verify_shared_filesystem(self, work_dir):
+        """Rank 0 only: verify all workers can access and write to work_dir.
+
+        On multi-node HPC jobs, default temporary directories (like /tmp)
+        live on node-local disks. If workers are on separate physical nodes
+        from Rank 0, intermediate file operations will fail. This method
+        dispatches lightweight test tasks to confirm cross-node read
+        visibility and write permissions before any expensive work begins.
+
+        Parameters
+        ----------
+        work_dir : path-like
+            The working directory path to test across all worker ranks.
+
+        Raises
+        ------
+        RuntimeError
+            If any worker rank fails to read from or write to ``work_dir``.
+        """
+        if self.comm is None or self.size <= 1:
+            return
+        if self.rank != 0:
+            raise RuntimeError(
+                "verify_shared_filesystem() must only be called by Rank 0."
+            )
+
+        work_dir_str = str(work_dir)
+        pid = os.getpid()
+        _logger.info(
+            f"Verifying shared filesystem visibility across "
+            f"{self.size - 1} worker rank(s)..."
+        )
+        rank0_test_file = os.path.join(
+            work_dir_str, f".mpi_fs_check_{pid}.tmp"
+        )
+        with open(rank0_test_file, 'w') as f:
+            f.write("rank0_ok")
+
+        try:
+            check_tasks = [
+                {
+                    'op': 'check_shared_fs',
+                    'original_index': idx,
+                    'work_dir': work_dir_str,
+                    'test_read_file': rank0_test_file,
+                    'worker_rank': idx + 1,
+                }
+                for idx in range(self.size - 1)
+            ]
+            check_results = self._dispatch(check_tasks)
+        finally:
+            if os.path.exists(rank0_test_file):
+                try:
+                    os.remove(rank0_test_file)
+                except OSError:
+                    pass
+
+        check_failures = [
+            res for res in check_results
+            if not isinstance(res, dict) or res.get('status') == 'error'
+        ]
+        if check_failures:
+            first_err = (
+                check_failures[0].get('error', repr(check_failures[0]))
+                if isinstance(check_failures[0], dict)
+                else repr(check_failures[0])
+            )
+            wrk = (
+                check_failures[0].get('worker_rank', '?')
+                if isinstance(check_failures[0], dict)
+                else '?'
+            )
+            raise RuntimeError(
+                f"\n[MPI Shared Filesystem Error] Worker rank {wrk} failed "
+                f"to access or write to working directory "
+                f"'{work_dir_str}':\n  {first_err}\n\n"
+                f"On multi-node HPC/cluster jobs, intermediate files must "
+                f"be created on a shared parallel filesystem (such as "
+                f"Lustre, GPFS, or NFS) visible to all nodes, rather than "
+                f"node-local /tmp.\n\n"
+                f"--> ACTION REQUIRED: Set the TMPDIR environment variable "
+                f"to point to your shared network filesystem before "
+                f"running OCSMesh:\n"
+                f"    export TMPDIR=/scratch/$USER\n"
+                f"    # or export TMPDIR=/lustre/..."
+            )
+        _logger.info("Shared filesystem check passed across all worker ranks.")
+
+    # ── Internal ──────────────────────────────────────────────────
+
+    def _dispatch(self, tasks, fail_fast=False):
+        """Rank-0-only: stream tasks dynamically to idle workers.
+
+        Seeds one task per worker, then refills each worker as soon as
+        it returns a result — a central work queue with on-demand
+        assignment. Returns the list of result/error dicts (order is
+        NOT the task order; use ``'original_index'`` to reassociate).
+
+        Parameters
+        ----------
+        tasks : list of dict
+            Self-describing task dicts, each with an ``'op'`` key.
+        fail_fast : bool, default=False
+            If True, stop dispatching new tasks as soon as the first
+            error result is received. In-flight tasks are still drained.
+
+        Returns
+        -------
+        list of dict
+            One result (or structured error) dict per task dispatched.
+        """
+        # ── Safety checks ──
+        if self.comm is None:
+            raise RuntimeError("mpi4py is not available")
+        if self.rank != 0:
+            raise RuntimeError(
+                "_dispatch() must only be called by Rank 0."
+            )
+        if not isinstance(tasks, list):
+            raise TypeError(
+                f"_dispatch() expects a list of task dicts, "
+                f"got {type(tasks).__name__}"
+            )
+
+        # Degenerate case: no workers (size == 1)
+        # Run tasks locally so single-rank runs stay correct.
+        if self.size == 1:
+            return self._run_tasks_locally(tasks)
+
+        results = []
+        task_iter = iter(tasks)
+        inflight = 0  # tasks currently being processed by workers
+        saw_error = False  # fail_fast: stop dispatching after first error
+
+        # ── Seed: give each worker one task to start ──
+        for worker in range(1, self.size):
+            task = next(task_iter, None)
+            if task is None:
+                break  # fewer tasks than workers
+            self.comm.send(task, dest=worker, tag=self._TAGS['TASK'])
+            inflight += 1
+
+        # ── Refill: as each worker reports back, hand it the next ──
+        MPI = _get_mpi()
+        while inflight > 0:
+            status = MPI.Status()
+            message = self.comm.recv(
+                source=MPI.ANY_SOURCE,
+                tag=MPI.ANY_TAG,
+                status=status,
+            )
+            worker = status.Get_source()
+            inflight -= 1
+            results.append(message)
+
+            # Check if this result is an error
+            if (isinstance(message, dict)
+                    and message.get('status') == 'error'):
+                saw_error = True
+
+            # Only dispatch new tasks if we haven't seen an error
+            # (or fail_fast is disabled). In-flight tasks continue
+            # to drain normally — we just stop sending NEW work.
+            if fail_fast and saw_error:
+                _logger.warning(
+                    f"fail_fast: error received from worker rank "
+                    f"{worker}; draining {inflight} in-flight task(s) "
+                    f"and skipping remaining queue."
+                )
+                continue
+
+            next_task = next(task_iter, None)
+            if next_task is not None:
+                self.comm.send(
+                    next_task, dest=worker, tag=self._TAGS['TASK'])
+                inflight += 1
+
+        return results
+
+    def _run_worker(self):
+        """Worker recv/execute/send loop (point-to-point).
+
+        Each non-zero rank calls this ONCE. The worker blocks in a
+        ``recv`` until rank 0 either hands it a task (``TAG_TASK``) or
+        tells it to stop (``TAG_STOP``). After running a task it sends
+        the result back and loops again.
+
+        A blocking ``recv`` is the correct idle-wait primitive: the
+        worker sleeps inside MPI without busy-polling and is woken only
+        when a message addressed to it arrives.
+        """
+        # ── Safety checks ──
+        if self.rank == 0:
+            raise RuntimeError(
+                "_run_worker() must only be called by worker ranks."
+            )
+
+        MPI = _get_mpi()
+        registry = self._worker_registry()
+        _logger.debug(
+            f"Rank {self.rank}: entering point-to-point worker loop"
+        )
+
+        while True:
+            # Block until rank 0 sends us something. ANY_TAG lets a
+            # single recv distinguish a task from a stop signal.
+            status = MPI.Status()
+            message = self.comm.recv(
+                source=0, tag=MPI.ANY_TAG, status=status)
+            tag = status.Get_tag()
+
+            if tag == self._TAGS['STOP']:
+                _logger.debug(
+                    f"Rank {self.rank}: received STOP, leaving loop"
+                )
+                break
+
+            if tag != self._TAGS['TASK']:
+                # Defensive: unknown control tag. Report and keep
+                # serving so a protocol slip does not silently hang.
+                _logger.warning(
+                    f"Rank {self.rank}: unexpected tag {tag!r}; "
+                    f"ignoring message"
+                )
+                continue
+
+            task = message
+            op = task.get('op') if isinstance(task, dict) else None
+            worker_fn = registry.get(op)
+
+            if worker_fn is None:
+                # Unknown operation -> structured error, worker stays.
+                self.comm.send(
+                    {
+                        'status': 'error',
+                        'original_index': (
+                            task.get('original_index', -1)
+                            if isinstance(task, dict) else -1),
+                        'op': op,
+                        'worker_rank': self.rank,
+                        'error': f"No worker registered for op "
+                                 f"{op!r}",
+                        'traceback': '',
+                    },
+                    dest=0, tag=self._TAGS['ERROR'],
+                )
+                continue
+
+            try:
+                result = worker_fn(task)
+                # Some worker functions catch their own exceptions
+                # and return {'status': 'error', ...}. Route those
+                # through the error channel too.
+                if (isinstance(result, dict)
+                        and result.get('status') == 'error'):
+                    result.setdefault('worker_rank', self.rank)
+                    self.comm.send(
+                        result, dest=0, tag=self._TAGS['ERROR'])
+                else:
+                    self.comm.send(
+                        result, dest=0, tag=self._TAGS['RESULT'])
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                # Task blew up — NOT an MPI rank failure. Catch it,
+                # report it, keep the worker available for more tasks.
+                self.comm.send(
+                    {
+                        'status': 'error',
+                        'original_index': (
+                            task.get('original_index', -1)
+                            if isinstance(task, dict) else -1),
+                        'op': op,
+                        'worker_rank': self.rank,
+                        'error': repr(exc),
+                        'traceback': traceback.format_exc(),
+                    },
+                    dest=0, tag=self._TAGS['ERROR'],
+                )
+
+        _logger.debug(
+            f"Rank {self.rank}: worker loop exited cleanly"
+        )
+
+    def _shutdown_workers(self):
+        """Send TAG_STOP to each worker individually.
+
+        Individual sends (not a collective) mean each worker exits
+        independently — if one already crashed, the others still
+        receive their stop signal cleanly.
+        """
+        _logger.debug(
+            f"Rank 0: sending STOP to {self.size - 1} worker(s)"
+        )
+        for worker in range(1, self.size):
+            self.comm.send(None, dest=worker, tag=self._TAGS['STOP'])
+
+    def _run_tasks_locally(self, tasks):
+        """Fallback for single-rank: run tasks without MPI."""
+        registry = self._worker_registry()
+        results = []
+        for task in tasks:
+            fn = registry.get(task.get('op'))
+            if fn is None:
+                results.append({
+                    'status': 'error',
+                    'original_index': task.get('original_index', -1),
+                    'error': f"No worker registered for op "
+                             f"{task.get('op')!r}",
+                })
+                continue
+            try:
+                results.append(fn(task))
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                results.append({
+                    'status': 'error',
+                    'original_index': task.get('original_index', -1),
+                    'error': repr(exc),
+                    'traceback': traceback.format_exc(),
+                })
+        return results
+

--- a/tests/api/mpi_failures_handling_test.py
+++ b/tests/api/mpi_failures_handling_test.py
@@ -67,16 +67,16 @@ class TestMPIFailuresHandling(unittest.TestCase):
         else:
             self.tdir = None
 
+        # bcast is collective — all ranks are synchronized when it returns.
         self.tdir = comm.bcast(self.tdir, root=0)
-        comm.Barrier()
 
         dem1_path = self.tdir / "dem1.tif"
         dem2_path = self.tdir / "dem2.tif"
         self.raster_list = [Raster(dem1_path), Raster(dem2_path)]
 
     def tearDown(self):
-        comm = MPI.COMM_WORLD
-        comm.Barrier()
+        # No barrier needed — execute() already synchronized
+        # all ranks before returning (workers exit recv loop on STOP).
         self.raster_list = None
         gc.collect()
         if self.rank == 0:
@@ -146,7 +146,6 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(successes[0]['original_index'], 1)
 
         executor.execute(pipeline)
-        MPI.COMM_WORLD.Barrier()
 
     def test_unregistered_op_recovery(self):
         """Worker survives an unregistered op and processes the next task."""
@@ -200,7 +199,6 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(successes[0]['original_index'], 1)
 
         executor.execute(pipeline)
-        MPI.COMM_WORLD.Barrier()
 
 
 if __name__ == "__main__":

--- a/tests/api/mpi_failures_handling_test.py
+++ b/tests/api/mpi_failures_handling_test.py
@@ -145,7 +145,7 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(len(successes), 1)
             self.assertEqual(successes[0]['original_index'], 1)
 
-        executor.execute(pipeline)
+        executor._execute(pipeline)
 
     def test_unregistered_op_recovery(self):
         """Worker survives an unregistered op and processes the next task."""
@@ -198,7 +198,7 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(len(successes), 1)
             self.assertEqual(successes[0]['original_index'], 1)
 
-        executor.execute(pipeline)
+        executor._execute(pipeline)
 
 
 if __name__ == "__main__":

--- a/tests/api/mpi_failures_handling_test.py
+++ b/tests/api/mpi_failures_handling_test.py
@@ -1,5 +1,7 @@
 """MPI integration tests for failure handling and soft-fail recovery (requires mpiexec -n 2)."""
 
+# pylint: disable=c-extension-no-member,protected-access
+
 import gc
 import shutil
 import tempfile

--- a/tests/api/mpi_failures_handling_test.py
+++ b/tests/api/mpi_failures_handling_test.py
@@ -15,12 +15,14 @@ from ocsmesh.mpi import MPIExecutor
 from ocsmesh.hfun.raster import HfunRaster
 from ocsmesh.utils import raster_from_numpy
 
-try:
-    from mpi4py import MPI
+from ocsmesh.mpi import _is_mpi_env_detected
 
-    IS_UNDER_MPIEXEC = MPI.COMM_WORLD.Get_size() > 1
-except ImportError:
-    IS_UNDER_MPIEXEC = False
+IS_UNDER_MPIEXEC = _is_mpi_env_detected()
+if IS_UNDER_MPIEXEC:
+    try:
+        from mpi4py import MPI
+    except ImportError:
+        IS_UNDER_MPIEXEC = False
 
 
 def _create_test_rasters(base_dir):

--- a/tests/api/mpi_failures_handling_test.py
+++ b/tests/api/mpi_failures_handling_test.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 
 from ocsmesh import Raster
-from ocsmesh.hfun.collector import MPITaskRunner
+from ocsmesh.mpi import MPIExecutor
 from ocsmesh.hfun.raster import HfunRaster
 from ocsmesh.utils import raster_from_numpy
 
@@ -31,15 +31,13 @@ def _create_test_rasters(base_dir):
     raster_from_numpy(dem1_path, dem_data, (grid_x, grid_y), 4326)
     raster_from_numpy(dem2_path, dem_data.copy(), (grid_x, grid_y), 4326)
 
-    return [Raster(dem1_path), Raster(dem2_path)]
-
 
 @unittest.skipUnless(IS_UNDER_MPIEXEC, "Requires mpiexec with >1 rank")
 class TestMPIFailuresHandling(unittest.TestCase):
     """Worker soft-fail and recovery tests — require exactly 2 MPI ranks (-n 2).
 
     With exactly 1 worker (n=2), dispatching [bad_task, good_task] in a
-    single runner.dispatch() call forces the same worker to handle both.
+    single executor._dispatch() call forces the same worker to handle both.
     If the good task succeeds, the worker survived the failure.
 
     If executed with n != 2 under mpiexec, setUp() fails explicitly with a
@@ -61,12 +59,16 @@ class TestMPIFailuresHandling(unittest.TestCase):
 
         if self.rank == 0:
             self.tdir = Path(tempfile.mkdtemp())
-            self.raster_list = _create_test_rasters(self.tdir)
+            _create_test_rasters(self.tdir)
         else:
             self.tdir = None
-            self.raster_list = None
 
         self.tdir = comm.bcast(self.tdir, root=0)
+        comm.Barrier()
+
+        dem1_path = self.tdir / "dem1.tif"
+        dem2_path = self.tdir / "dem2.tif"
+        self.raster_list = [Raster(dem1_path), Raster(dem2_path)]
 
     def tearDown(self):
         comm = MPI.COMM_WORLD
@@ -81,10 +83,10 @@ class TestMPIFailuresHandling(unittest.TestCase):
 
     def test_task_exception_recovery(self):
         """Worker survives a task exception and processes the next task."""
-        runner = MPITaskRunner()
+        executor = MPIExecutor()
         out_path = str(self.tdir / "recovery_test")
 
-        def main():
+        def pipeline():
             raster = self.raster_list[0]
 
             # ── BAD TASK ────────────────────────────────────────────
@@ -118,7 +120,7 @@ class TestMPIFailuresHandling(unittest.TestCase):
             }
 
             # Single dispatch — 1 worker handles both sequentially
-            results = runner.dispatch([bad_task, good_task])
+            results = executor._dispatch([bad_task, good_task])
 
             self.assertEqual(len(results), 2)
 
@@ -139,20 +141,20 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(len(successes), 1)
             self.assertEqual(successes[0]['original_index'], 1)
 
-        runner.run(main)
+        executor.execute(pipeline)
         MPI.COMM_WORLD.Barrier()
 
     def test_unregistered_op_recovery(self):
         """Worker survives an unregistered op and processes the next task."""
-        runner = MPITaskRunner()
+        executor = MPIExecutor()
         out_path = str(self.tdir / "unreg_recovery_test")
 
-        def main():
+        def pipeline():
             raster = self.raster_list[0]
 
             # ── INVALID TASK ────────────────────────────────────────
             # Definition: Uses an operation name ('op': 'nonexistent_operation')
-            # that is NOT registered in MPITaskRunner._worker_registry().
+            # that is NOT registered in MPIExecutor._worker_registry().
             invalid_task = {
                 'op': 'nonexistent_operation',
                 'original_index': 0,
@@ -173,7 +175,7 @@ class TestMPIFailuresHandling(unittest.TestCase):
                 'meshdata_kwargs': {}
             }
 
-            results = runner.dispatch([invalid_task, good_task])
+            results = executor._dispatch([invalid_task, good_task])
 
             self.assertEqual(len(results), 2)
 
@@ -193,7 +195,7 @@ class TestMPIFailuresHandling(unittest.TestCase):
             self.assertEqual(len(successes), 1)
             self.assertEqual(successes[0]['original_index'], 1)
 
-        runner.run(main)
+        executor.execute(pipeline)
         MPI.COMM_WORLD.Barrier()
 
 

--- a/tests/api/mpi_write_hfun_test.py
+++ b/tests/api/mpi_write_hfun_test.py
@@ -52,16 +52,16 @@ class TestMPIWriteHfun(unittest.TestCase):
         else:
             self.tdir = None
 
+        # bcast is collective — all ranks are synchronized when it returns.
         self.tdir = comm.bcast(self.tdir, root=0)
-        comm.Barrier()
 
         dem1_path = self.tdir / "dem1.tif"
         dem2_path = self.tdir / "dem2.tif"
         self.raster_list = [Raster(dem1_path), Raster(dem2_path)]
 
     def tearDown(self):
-        comm = MPI.COMM_WORLD
-        comm.Barrier()
+        # No barrier needed — MPIExecutor.run() already synchronized
+        # all ranks before returning (workers exit recv loop on STOP).
         self.raster_list = None
         gc.collect()
         if self.rank == 0:
@@ -82,8 +82,6 @@ class TestMPIWriteHfun(unittest.TestCase):
             self.assertTrue(len(meshdata.coords) > 0)
         else:
             self.assertIsNone(meshdata)
-
-        MPI.COMM_WORLD.Barrier()
 
     def test_serial_vs_mpi_write_hfun_equivalence(self):
         """Numerical equivalence: serial meshdata == MPI meshdata."""
@@ -129,8 +127,6 @@ class TestMPIWriteHfun(unittest.TestCase):
             npt.assert_allclose(
                 np.mean(values_serial), np.mean(values_mpi), rtol=1e-5
             )
-
-        MPI.COMM_WORLD.Barrier()
 
 
 if __name__ == "__main__":

--- a/tests/api/mpi_write_hfun_test.py
+++ b/tests/api/mpi_write_hfun_test.py
@@ -12,6 +12,8 @@ import numpy as np
 import numpy.testing as npt
 
 from ocsmesh import Hfun, Raster
+from ocsmesh.mpi import MPIExecutor
+from ocsmesh.hfun.raster import HfunRaster
 from ocsmesh.utils import raster_from_numpy
 
 from ocsmesh.mpi import _is_mpi_env_detected
@@ -127,6 +129,74 @@ class TestMPIWriteHfun(unittest.TestCase):
             npt.assert_allclose(
                 np.mean(values_serial), np.mean(values_mpi), rtol=1e-5
             )
+
+    def test_run_classmethod_workers_in_recv_loop(self):
+        """Simple test to verify that workers are in their recv loop when run() is called. "No deadlock"
+        """
+        raster = self.raster_list[0] if self.raster_list else None
+
+        if MPIExecutor.is_manager() and raster is not None:
+            valid_hfun = HfunRaster(
+                raster=raster, hmin=10, hmax=1000
+            )
+            out_path = str(self.tdir / "run_recv_test")
+            tasks = [{
+                'op': 'meshdata',
+                'type': 'raster',
+                'original_index': 0,
+                'topo_path': raster.path,
+                'hfun_input_path': valid_hfun.tmpfile,
+                'output_path': out_path,
+                'hmin': 10,
+                'hmax': 1000,
+                'meshdata_kwargs': {}
+            }]
+        else:
+            tasks = [{'op': 'meshdata', 'original_index': 0}]
+
+        # No work_dir → submit() skips verify_shared_filesystem(),
+        # goes straight to _dispatch().
+        result = MPIExecutor.run(tasks)
+
+        if MPIExecutor.is_manager():
+            self.assertIsNotNone(result)
+            self.assertIn(0, result)
+        else:
+            self.assertIsNone(result)
+
+    def test_verify_shared_fs_inside_run(self):
+        """Simple test to verify that workers are in their recv loop when run() is called with work_dir. "NO Deadlock"
+        """
+        raster = self.raster_list[0] if self.raster_list else None
+
+        if MPIExecutor.is_manager() and raster is not None:
+            valid_hfun = HfunRaster(
+                raster=raster, hmin=10, hmax=1000
+            )
+            out_path = str(self.tdir / "fs_check_test")
+            tasks = [{
+                'op': 'meshdata',
+                'type': 'raster',
+                'original_index': 0,
+                'topo_path': raster.path,
+                'hfun_input_path': valid_hfun.tmpfile,
+                'output_path': out_path,
+                'hmin': 10,
+                'hmax': 1000,
+                'meshdata_kwargs': {}
+            }]
+        else:
+            tasks = [{'op': 'meshdata', 'original_index': 0}]
+
+        # work_dir=self.tdir → submit() calls verify_shared_filesystem()
+        # which fires its own _dispatch(check_tasks) BEFORE the main dispatch.
+        result = MPIExecutor.run(tasks, work_dir=self.tdir)
+
+        if MPIExecutor.is_manager():
+            self.assertIsNotNone(result)
+            self.assertIn(0, result)
+        else:
+            self.assertIsNone(result)
 
 
 if __name__ == "__main__":

--- a/tests/api/mpi_write_hfun_test.py
+++ b/tests/api/mpi_write_hfun_test.py
@@ -1,5 +1,7 @@
 """MPI integration tests for Hfun write path (requires mpiexec)."""
 
+# pylint: disable=c-extension-no-member
+
 import gc
 import shutil
 import tempfile

--- a/tests/api/mpi_write_hfun_test.py
+++ b/tests/api/mpi_write_hfun_test.py
@@ -10,7 +10,6 @@ import numpy as np
 import numpy.testing as npt
 
 from ocsmesh import Hfun, Raster
-from ocsmesh.hfun.collector import MPITaskRunner
 from ocsmesh.utils import raster_from_numpy
 
 try:
@@ -31,14 +30,12 @@ def _create_test_rasters(base_dir):
     raster_from_numpy(dem1_path, dem_data, (grid_x, grid_y), 4326)
     raster_from_numpy(dem2_path, dem_data.copy(), (grid_x, grid_y), 4326)
 
-    return [Raster(dem1_path), Raster(dem2_path)]
-
 
 @unittest.skipUnless(IS_UNDER_MPIEXEC, "Requires mpiexec with >1 rank")
 class TestMPIWriteHfun(unittest.TestCase):
-    """Test meshdata() write path under MPI using MPITaskRunner.
+    """Test meshdata() write path under MPI.
 
-    Run with: mpiexec -n 2 python -m pytest tests/api/test_mpi_write_hfun.py -v -s
+    Run with: mpiexec -n 2 python -m pytest tests/api/mpi_write_hfun_test.py -v -s
     """
 
     def setUp(self):
@@ -47,12 +44,16 @@ class TestMPIWriteHfun(unittest.TestCase):
 
         if self.rank == 0:
             self.tdir = Path(tempfile.mkdtemp())
-            self.raster_list = _create_test_rasters(self.tdir)
+            _create_test_rasters(self.tdir)
         else:
             self.tdir = None
-            self.raster_list = None
 
         self.tdir = comm.bcast(self.tdir, root=0)
+        comm.Barrier()
+
+        dem1_path = self.tdir / "dem1.tif"
+        dem2_path = self.tdir / "dem2.tif"
+        self.raster_list = [Raster(dem1_path), Raster(dem2_path)]
 
     def tearDown(self):
         comm = MPI.COMM_WORLD
@@ -67,61 +68,50 @@ class TestMPIWriteHfun(unittest.TestCase):
 
     def test_mpi_write_hfun_basic(self):
         """Basic smoke test: MPI meshdata() produces valid output."""
-        runner = MPITaskRunner()
+        hfun = Hfun(self.raster_list, nprocs=1, hmin=10, hmax=1000)
+        hfun.execution_mode = "mpi"
+        meshdata = hfun.meshdata()
 
-        def main():
-            hfun = Hfun(self.raster_list, nprocs=1, hmin=10, hmax=1000)
-            hfun.execution_mode = "mpi"
-            meshdata = hfun.meshdata()
-
+        if self.rank == 0:
             self.assertIsNotNone(meshdata)
             self.assertTrue(len(meshdata.values) > 0)
             self.assertTrue(len(meshdata.coords) > 0)
-            return meshdata
-
-        result = runner.run(main)
-
-        if self.rank == 0:
-            self.assertIsNotNone(result)
         else:
-            self.assertIsNone(result)
+            self.assertIsNone(meshdata)
 
         MPI.COMM_WORLD.Barrier()
 
     def test_serial_vs_mpi_write_hfun_equivalence(self):
         """Numerical equivalence: serial meshdata == MPI meshdata."""
-        runner = MPITaskRunner()
+        # ── SERIAL baseline ──
+        hfun_serial = Hfun(
+            self.raster_list, nprocs=2, hmin=10, hmax=1000
+        )
+        hfun_serial.execution_mode = "serial"
+        hfun_serial.add_subtidal_flow_limiter(
+            hmin=50, lower_bound=-5, upper_bound=5
+        )
+        hfun_serial.add_constant_value(
+            value=200, lower_bound=5, upper_bound=10
+        )
+        meshdata_serial = hfun_serial.meshdata()
 
-        def main():
-            # ── SERIAL baseline ──
-            hfun_serial = Hfun(
-                self.raster_list, nprocs=2, hmin=10, hmax=1000
-            )
-            hfun_serial.execution_mode = "serial"
-            hfun_serial.add_subtidal_flow_limiter(
-                hmin=50, lower_bound=-5, upper_bound=5
-            )
-            hfun_serial.add_constant_value(
-                value=200, lower_bound=5, upper_bound=10
-            )
-            meshdata_serial = hfun_serial.meshdata()
+        # ── MPI execution ──
+        hfun_mpi = Hfun(
+            self.raster_list, nprocs=2, hmin=10, hmax=1000
+        )
+        hfun_mpi.execution_mode = "mpi"
+        hfun_mpi.add_subtidal_flow_limiter(
+            hmin=50, lower_bound=-5, upper_bound=5
+        )
+        hfun_mpi.add_constant_value(
+            value=200, lower_bound=5, upper_bound=10
+        )
+        meshdata_mpi = hfun_mpi.meshdata()
+
+        if self.rank == 0:
             values_serial = meshdata_serial.values
-
-            # ── MPI execution ──
-            hfun_mpi = Hfun(
-                self.raster_list, nprocs=2, hmin=10, hmax=1000
-            )
-            hfun_mpi.execution_mode = "mpi"
-            hfun_mpi.add_subtidal_flow_limiter(
-                hmin=50, lower_bound=-5, upper_bound=5
-            )
-            hfun_mpi.add_constant_value(
-                value=200, lower_bound=5, upper_bound=10
-            )
-            meshdata_mpi = hfun_mpi.meshdata()
             values_mpi = meshdata_mpi.values
-
-            # ── COMPARE ──
             self.assertAlmostEqual(
                 len(values_serial), len(values_mpi),
                 delta=len(values_serial) * 0.01,
@@ -136,7 +126,6 @@ class TestMPIWriteHfun(unittest.TestCase):
                 np.mean(values_serial), np.mean(values_mpi), rtol=1e-5
             )
 
-        runner.run(main)
         MPI.COMM_WORLD.Barrier()
 
 

--- a/tests/api/mpi_write_hfun_test.py
+++ b/tests/api/mpi_write_hfun_test.py
@@ -14,12 +14,14 @@ import numpy.testing as npt
 from ocsmesh import Hfun, Raster
 from ocsmesh.utils import raster_from_numpy
 
-try:
-    from mpi4py import MPI
+from ocsmesh.mpi import _is_mpi_env_detected
 
-    IS_UNDER_MPIEXEC = MPI.COMM_WORLD.Get_size() > 1
-except ImportError:
-    IS_UNDER_MPIEXEC = False
+IS_UNDER_MPIEXEC = _is_mpi_env_detected()
+if IS_UNDER_MPIEXEC:
+    try:
+        from mpi4py import MPI
+    except ImportError:
+        IS_UNDER_MPIEXEC = False
 
 
 def _create_test_rasters(base_dir):

--- a/tests/api/test_mpi_mode_property.py
+++ b/tests/api/test_mpi_mode_property.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from ocsmesh import Hfun, Raster
-from ocsmesh.hfun.collector import MPITaskRunner
+from ocsmesh.mpi import MPIExecutor
 from ocsmesh.utils import raster_from_numpy
 
 
@@ -57,7 +57,7 @@ class TestMPIModeProperty(unittest.TestCase):
             hfun.execution_mode = "mpi"
         self.assertIn("Falling back", str(cm.warning))
 
-    @patch("ocsmesh.hfun.collector._get_mpi", return_value=None)
+    @patch("ocsmesh.mpi._get_mpi", return_value=None)
     def test_mpi_mode_fallback_no_mpi4py(self, mock_get_mpi):
         """Setting mode='mpi' without mpi4py falls back with warning."""
         hfun = Hfun(self.raster_list, nprocs=2)
@@ -76,7 +76,7 @@ class TestMPIModeProperty(unittest.TestCase):
 class TestMPIExcepthookUnit(unittest.TestCase):
     """Unit tests for install_mpi_excepthook behavior using mocks."""
 
-    @patch("ocsmesh.hfun.collector._get_mpi")
+    @patch("ocsmesh.mpi._get_mpi")
     def test_excepthook_installed_and_aborts_comm(self, mock_get_mpi):
         mock_comm = MagicMock()
         mock_comm.Get_rank.return_value = 1
@@ -86,7 +86,10 @@ class TestMPIExcepthookUnit(unittest.TestCase):
 
         original_excepthook = sys.excepthook
         try:
-            MPITaskRunner.install_mpi_excepthook()
+            # Reset excepthook attribute if previously patched
+            if hasattr(sys.excepthook, '_is_mpi_hook'):
+                delattr(sys.excepthook, '_is_mpi_hook')
+            MPIExecutor.install_mpi_excepthook()
             self.assertNotEqual(sys.excepthook, original_excepthook)
 
             # Trigger the installed excepthook
@@ -97,11 +100,13 @@ class TestMPIExcepthookUnit(unittest.TestCase):
         finally:
             sys.excepthook = original_excepthook
 
-    @patch("ocsmesh.hfun.collector._get_mpi", return_value=None)
+    @patch("ocsmesh.mpi._get_mpi", return_value=None)
     def test_excepthook_no_op_when_no_mpi(self, mock_get_mpi):
         original_excepthook = sys.excepthook
         try:
-            MPITaskRunner.install_mpi_excepthook()
+            if hasattr(sys.excepthook, '_is_mpi_hook'):
+                delattr(sys.excepthook, '_is_mpi_hook')
+            MPIExecutor.install_mpi_excepthook()
             self.assertEqual(sys.excepthook, original_excepthook)
         finally:
             sys.excepthook = original_excepthook

--- a/tests/api/test_mpi_mode_property.py
+++ b/tests/api/test_mpi_mode_property.py
@@ -86,9 +86,7 @@ class TestMPIExcepthookUnit(unittest.TestCase):
 
         original_excepthook = sys.excepthook
         try:
-            # Reset excepthook attribute if previously patched
-            if hasattr(sys.excepthook, '_is_mpi_hook'):
-                delattr(sys.excepthook, '_is_mpi_hook')
+            sys.excepthook = sys.__excepthook__
             MPIExecutor.install_mpi_excepthook()
             self.assertNotEqual(sys.excepthook, original_excepthook)
 
@@ -104,8 +102,7 @@ class TestMPIExcepthookUnit(unittest.TestCase):
     def test_excepthook_no_op_when_no_mpi(self, mock_get_mpi):
         original_excepthook = sys.excepthook
         try:
-            if hasattr(sys.excepthook, '_is_mpi_hook'):
-                delattr(sys.excepthook, '_is_mpi_hook')
+            sys.excepthook = sys.__excepthook__
             MPIExecutor.install_mpi_excepthook()
             self.assertEqual(sys.excepthook, original_excepthook)
         finally:

--- a/tests/api/test_mpi_mode_property.py
+++ b/tests/api/test_mpi_mode_property.py
@@ -100,9 +100,12 @@ class TestMPIExcepthookUnit(unittest.TestCase):
 
     @patch("ocsmesh.mpi._get_mpi", return_value=None)
     def test_excepthook_no_op_when_no_mpi(self, mock_get_mpi):
+        """install_mpi_excepthook should be a no-op when MPI is unavailable."""
         original_excepthook = sys.excepthook
         try:
-            sys.excepthook = sys.__excepthook__
+            # No reset here — we're verifying that install_mpi_excepthook
+            # leaves sys.excepthook completely untouched when _get_mpi()
+            # returns None.
             MPIExecutor.install_mpi_excepthook()
             self.assertEqual(sys.excepthook, original_excepthook)
         finally:

--- a/tests/api/test_mpi_mode_property.py
+++ b/tests/api/test_mpi_mode_property.py
@@ -63,7 +63,7 @@ class TestMPIModeProperty(unittest.TestCase):
         hfun = Hfun(self.raster_list, nprocs=2)
         with self.assertWarns(UserWarning) as cm:
             hfun.execution_mode = "mpi"
-        self.assertIn("mpi4py is not installed", str(cm.warning))
+        self.assertIn("MPI environment detected", str(cm.warning))
         self.assertEqual(hfun.execution_mode, "parallel")
 
     def test_invalid_mode_raises(self):


### PR DESCRIPTION
## Overview
This PR fundamentally refactors OCSMesh's MPI execution model. Previously, the user was required to explicitly instantiate an `MPITaskRunner` and wrap their code inside a runner callback (e.g., `runner.run(...)`).

This PR abstracts the MPI execution away from the user script. Now, users simply write their standard sequential-looking OCSMesh scripts and set the `execution_mode = 'mpi'` property. The internal collectors handle the MPI distribution transparently via a Singleton `MPIExecutor`, eliminating boilerplate and the need for the user to understand MPI worker loops.

## How the User Experience Changes

**Before (Explicit Runner Required):**
```python
from ocsmesh.mpi import MPITaskRunner

def my_script():
    hfun = Hfun(...)
    hfun.execution_mode = 'mpi'
    hfun.meshdata()

if __name__ == "__main__":
    runner = MPITaskRunner()
    if runner.rank == 0:
        runner.run(my_script)
    else:
        # Workers had to explicitly block
        runner.run(lambda: None) 
```

**After (Transparent Execution):**
```python
# The user writes a standard script. No MPITaskRunner boilerplate required!
hfun = Hfun(...)
hfun.execution_mode = 'mpi'

# OCSMesh handles the manager/worker distribution internally!
hfun.meshdata() 
```

## How It Works Internally
1. **Singleton `MPIExecutor`**: We introduced an `MPIExecutor` class implemented as a Singleton. This allows any submodule (like `HfunCollector`) to grab the exact same MPI context and communicator without the user passing it around.
2. **Transparent Interception**: When a user calls a top-level function like `hfun.meshdata()`, if `execution_mode == 'mpi'`, the collector internally grabs the `MPIExecutor` and invokes `executor.execute()`. 
3. **Manager vs. Worker Split**: Inside `executor.execute()`:
   - **Rank 0 (Manager)** executes the actual collector logic, calling `executor.submit(...)` to distribute tasks (e.g., raster processing) dynamically.
   - **Ranks > 0 (Workers)** are transparently routed into a blocking `_run_worker()` loop. They wait for tasks from Rank 0, process them, and return results.
4. **Graceful Shutdown**: The manager (Rank 0) uses a `try/finally` block to send a `TAG_STOP` message to all workers once the pipeline finishes, ensuring the script exits cleanly without any user intervention.