### PR TITLE
feat/parallize apply contours

### DIFF
--- a/ocsmesh/hfun/collector.py
+++ b/ocsmesh/hfun/collector.py
@@ -206,6 +206,11 @@ class _RefinementContourCollector:
                 self._container.append((feather_path, crs_path))
 
 
+    @property
+    def files(self) -> List[Tuple[Path, Path]]:
+        return list(self._container)
+
+
     def __iter__(self) -> gpd.GeoDataFrame:
         """Iterator method for this collection object
 
@@ -714,6 +719,95 @@ def _constraints_task_worker(task: dict):
     }
 
 
+def _contours_task_worker(task: dict):
+    """
+    A self-contained worker for applying contour refinements to a single
+    HfunRaster.
+
+    The coordinator has already extracted the contours to feather files on
+    disk, so this worker only needs plain paths: it rebuilds the HfunRaster
+    inside the child process (raster handles cannot be pickled), replays
+    every contour line onto it, and saves the result to a new file.
+    """
+
+    # 1. Unpack the simple, pickleable task description
+    original_index = task['original_index']
+    hfun_input_path = task['hfun_input_path']
+    topo_input_path = task['topo_input_path']
+    output_path = task['output_path']
+    global_hmin = task['global_hmin']
+    global_hmax = task['global_hmax']
+    contour_files = task['contour_files']
+
+    try:
+        # 2. Create the necessary Raster and HfunRaster instances INSIDE
+        #    the worker.
+        topo_raster = Raster(topo_input_path)
+        worker_hfun = HfunRaster(
+            raster=topo_raster,
+            hmin=global_hmin,
+            hmax=global_hmax,
+            verbosity=0,
+            initial_value=hfun_input_path
+        )
+        # Taken from the rebuilt object rather than sent in the task, so
+        # it is exactly the CRS the serial path would compare against.
+        hfun_crs = worker_hfun.crs
+
+        # 3. Replay every contour line onto this raster.
+        for feather_path, crs_path in contour_files:
+            gdf = gpd.read_feather(feather_path)
+            with open(crs_path) as fp:
+                # Read the CRS the same way _RefinementContourCollector
+                # does, so serial and parallel see identical input.
+                gdf = gdf.set_crs(
+                    CRS.from_json(fp.read()), allow_override=True)
+
+            # Built once per file: creating a Transformer is expensive and
+            # every row in the file shares the same source CRS.
+            transformer = None
+            if not gdf.crs.equals(hfun_crs):
+                _logger.info("Reprojecting feature...")
+                transformer = Transformer.from_crs(
+                    gdf.crs, hfun_crs, always_xy=True)
+
+            for row in gdf.itertuples():
+                _logger.debug(row)
+                shape = row.geometry
+                # Checked before any CRS work: reprojecting an empty
+                # GeometryCollection raises.
+                if isinstance(shape, GeometryCollection):
+                    continue
+                if transformer is not None:
+                    shape = ops.transform(transformer.transform, shape)
+
+                # nprocs=1 -> add_pool_args passes pool=None -> no child
+                # process. Required: we are already inside a daemon worker.
+                worker_hfun.add_feature(**{
+                    'feature': shape,
+                    'expansion_rate': row.expansion_rate,
+                    'target_size': row.target_size,
+                    'nprocs': 1
+                })
+
+        # 4. Save the final state to the designated output path.
+        worker_hfun.save(output_path)
+
+        # 5. Return a simple result dictionary.
+        return {
+            'status': 'success',
+            'original_index': original_index,
+            'output_path': output_path
+        }
+
+    except Exception:  # pylint: disable=broad-exception-caught
+        return {
+            'status': 'error',
+            'original_index': original_index,
+            'error': traceback.format_exc()
+        }
+
+
 def _meshdata_task_worker(task: dict):
     """Worker that calls hfun.meshdata() on a single hfun entry.
 
@@ -849,13 +943,14 @@ class HfunCollector(BaseHfun):
         gradient of the topography within the region between
         specified by lower and upper bound on topography.
         This refinement is only applied on rasters with specified
-        indices. The index is w.r.t the full input list for collector
-        object creation.
+        indices. The index counts raster inputs only, in the order
+        they were passed to the collector.
     add_constant_value(...)
         Add fixed size mesh refinement in the region specified by
         upper and lower bounds on topography.  This refinement is
-        only applied on rasters with specified indices. The index is
-        w.r.t the full input list for collector object creation.
+        only applied on rasters with specified indices. The index
+        counts raster inputs only, in the order they were passed to
+        the collector.
 
     Notes
     -----
@@ -1956,7 +2051,42 @@ class HfunCollector(BaseHfun):
 
 
     def _apply_contours(self, apply_to: Optional[SizeFuncList] = None) -> None:
-        """Internal: apply specified constraints.
+        """Internal: dispatch contour application to serial or parallel.
+
+        Parameters
+        ----------
+        apply_to : SizeFuncList or None, default=None
+            Size functions on which contours must be applied. If `None`
+            all inputs are used to apply the calculated contours.
+
+        Returns
+        -------
+        None
+
+        See Also
+        --------
+        _apply_contours_serial :
+        _apply_contours_parallel :
+        """
+
+        # The 'fast' method builds a throw-away big raster that is not in
+        # self._hfun_list, so the parallel path (which writes results back
+        # by list position) cannot be used for it.
+        if (self._method != 'fast'
+                and self.execution_mode in ('parallel', 'mpi')
+                and self._nprocs > 1):
+            _logger.info("Applying contours using PARALLEL method.")
+            self._apply_contours_parallel(apply_to)
+        else:
+            _logger.info("Applying contours using SERIAL method.")
+            self._apply_contours_serial(apply_to)
+
+
+    def _apply_contours_serial(
+            self,
+            apply_to: Optional[SizeFuncList] = None
+            ) -> None:
+        """Internal: apply specified contours one size function at a time.
 
         Parameters
         ----------
@@ -2014,13 +2144,165 @@ class HfunCollector(BaseHfun):
                             })
             p.join()
 
-            # hfun objects cause issue with pickling
-            # -> cannot be passed to pool
-#            with Pool(processes=self._nprocs) as p:
-#                p.starmap(
-#                    _apply_contours_worker,
-#                    [(hfun, self._contour_coll, self._nprocs)
-#                     for hfun in apply_to])
+
+    def _apply_contours_parallel(
+            self,
+            apply_to: Optional[SizeFuncList] = None
+            ) -> None:
+        """Internal: apply specified contours in parallel.
+
+        Uses the same 3-phase pattern as ``_apply_flow_limiters_parallel``:
+
+        1. **Preparation** — extract the contours once on the coordinator,
+           then build one pickleable task dict per raster size function.
+        2. **Execution** — ``Pool.map()`` sends tasks to
+           ``_contours_task_worker`` processes.
+        3. **Integration** — replace ``self._hfun_list`` entries with new
+           ``HfunRaster`` objects built from the worker output files.
+
+        Mesh size functions and the base mesh are handled on the
+        coordinator, because only rasters can be rebuilt from a file path
+        inside a worker.
+
+        Parameters
+        ----------
+        apply_to : SizeFuncList or None, default=None
+            Size functions on which contours must be applied. If `None`
+            all inputs are used to apply the calculated contours.
+
+        Returns
+        -------
+        None
+        """
+
+        raster_hfun_list = [
+            i for i in self._hfun_list if isinstance(i, HfunRaster)]
+        if apply_to is None:
+            mesh_hfun_list = [
+                i for i in self._hfun_list if isinstance(i, HfunMesh)]
+            if self._base_mesh and self._base_as_hfun:
+                mesh_hfun_list.insert(0, self._base_mesh)
+            apply_to = [*mesh_hfun_list, *raster_hfun_list]
+
+        # apply_to can hold objects that are NOT in self._hfun_list (the
+        # base mesh is one), so we match by object identity instead of by
+        # position. Anything we cannot look up, or that is not a raster,
+        # stays on the coordinator.
+        # A dict also means the same hfun listed twice becomes one task,
+        # which keeps two workers from writing the same output file.
+        idx_by_id = {id(h): i for i, h in enumerate(self._hfun_list)}
+        parallel_targets = {}
+        serial_targets = []
+        for hfun in apply_to:
+            idx = idx_by_id.get(id(hfun))
+            if idx is not None and isinstance(hfun, HfunRaster):
+                parallel_targets[idx] = hfun
+            else:
+                serial_targets.append(hfun)
+
+        # The worker rebuilds a bare HfunRaster, so any constraint already
+        # attached to the original would be silently dropped. Safe today
+        # because _apply_features runs contours first and constraints last.
+        if any(h._constraints  # pylint: disable=W0212
+               for h in parallel_targets.values()):
+            raise RuntimeError(
+                "_apply_contours_parallel cannot run after constraints "
+                "have been added; contours must be applied first.")
+
+        # Contours go under _work_dir rather than a local temp dir: an MPI
+        # job spreads over nodes, and /tmp is not shared between them.
+        contour_dir = os.path.join(self._work_dir, 'contours')
+        os.makedirs(contour_dir, exist_ok=True)
+
+        try:
+            # Phase 1: PREPARATION (Coordinator)
+            # Contours are ONLY extracted from raster sources
+            self._contour_coll.calculate(raster_hfun_list, contour_dir)
+            contour_file_list = self._contour_coll.files
+
+            tasks = []
+            for idx, hfun in parallel_targets.items():
+                task = {
+                    'original_index': idx,
+                    'hfun_input_path': hfun.tmpfile,
+                    'topo_input_path': hfun._raster.path,  # pylint: disable=W0212
+                    'output_path': os.path.join(
+                        self._work_dir, f"contours_result_{idx}.tif"),
+                    'global_hmin': hfun._hmin,  # pylint: disable=W0212
+                    'global_hmax': hfun._hmax,  # pylint: disable=W0212
+                    'contour_files': contour_file_list,
+                }
+                tasks.append(task)
+
+            if not tasks:
+                _logger.info("No contour tasks to execute.")
+            else:
+                # Phase 2: EXECUTION
+                _logger.info(
+                    f"Start parallel execution for {len(tasks)} contour tasks")
+                # Cap workers at the number of tasks: spawning more workers
+                # than tasks wastes spawn time and memory with idle processes.
+                n_workers = min(self._nprocs, len(tasks))
+                with Pool(processes=n_workers) as p:
+                    results = p.map(_contours_task_worker, tasks)
+                _logger.info("Parallel execution finished.")
+
+                # Fail fast. Skipping a failed task would leave a size
+                # function quietly missing its contours, which is worse
+                # than stopping here.
+                failures = [r for r in results if r['status'] == 'error']
+                if failures:
+                    msgs = [f"  idx {r['original_index']}: {r['error']}"
+                            for r in failures]
+                    raise RuntimeError(
+                        f"{len(failures)} contour worker(s) failed:\n"
+                        + "\n".join(msgs))
+
+                # Phase 3: INTEGRATION
+                for result in results:
+                    idx = result['original_index']
+                    original_hfun = self._hfun_list[idx]
+                    _logger.info(
+                        f"Update HfunCollector with contour raster at idx {idx}.")
+                    self._hfun_list[idx] = HfunRaster(
+                        raster=original_hfun.raster,
+                        hmin=original_hfun.hmin,
+                        hmax=original_hfun.hmax,
+                        verbosity=original_hfun.verbosity,
+                        initial_value=result['output_path']
+                    )
+
+            # Mesh size functions and the base mesh, done here. This has to
+            # happen before contour_dir is deleted, because iterating
+            # _contour_coll re-reads the feather files from disk.
+            if serial_targets:
+                with Pool(processes=self._nprocs) as p:
+                    for hfun in serial_targets:
+                        for gdf in self._contour_coll:
+                            for row in gdf.itertuples():
+                                _logger.debug(row)
+                                shape = row.geometry
+                                if isinstance(shape, GeometryCollection):
+                                    continue
+                                # NOTE: CRS check is done AFTER
+                                # GeometryCollection check because
+                                # gdf.to_crs results in an error in case
+                                # of empty GeometryCollection
+                                if not gdf.crs.equals(hfun.crs):
+                                    _logger.info("Reprojecting feature...")
+                                    transformer = Transformer.from_crs(
+                                        gdf.crs, hfun.crs, always_xy=True)
+                                    shape = ops.transform(
+                                            transformer.transform, shape)
+                                hfun.add_feature(**{
+                                    'feature': shape,
+                                    'expansion_rate': row.expansion_rate,
+                                    'target_size': row.target_size,
+                                    'pool': p
+                                })
+        finally:
+            shutil.rmtree(contour_dir, ignore_errors=True)
+
 
     def _apply_channels(self, apply_to: Optional[SizeFuncList] = None) -> None:
         """Internal: apply specified channel refinements.
@@ -2218,14 +2500,22 @@ class HfunCollector(BaseHfun):
         # First, group all applicable refinement rules by the HfunRaster they apply to.
         # This is more efficient than creating a separate task for every single rule.
 
-        raster_hfun_list = [
-            i for i in self._hfun_list if isinstance(i, HfunRaster)]
+        # Two counters on purpose:
+        #   raster_idx -> counts rasters only. This is what the user's
+        #                 `source_index` refers to, same as the serial path.
+        #   hfun_idx   -> the real slot in _hfun_list, used to put the result
+        #                 back. If we used raster_idx for this, a mesh size
+        #                 function earlier in the list would be overwritten.
+        raster_idx = -1
+        for hfun_idx, hfun in enumerate(self._hfun_list):
+            if not isinstance(hfun, HfunRaster):
+                continue
+            raster_idx += 1
 
-        for in_idx, hfun in enumerate(raster_hfun_list):
             limiter_rules_for_this_hfun = []
             for src_idx, hmin, hmax, zmax, zmin in self._flow_lim_coll:
                 # Check if the rule applies to this specific hfun instance
-                if src_idx is None or in_idx in src_idx:
+                if src_idx is None or raster_idx in src_idx:
                     limiter_rules_for_this_hfun.append({
                     'hmin': hmin if hmin is not None else self._size_info.get('hmin'),
                     'hmax': hmax if hmax is not None else self._size_info.get('hmax'),
@@ -2235,7 +2525,7 @@ class HfunCollector(BaseHfun):
 
             # If any rules were found, mark this HfunRaster for processing.
             if limiter_rules_for_this_hfun:
-                hfuns_to_process[in_idx] = {
+                hfuns_to_process[hfun_idx] = {
                     'hfun': hfun,
                     'rules': limiter_rules_for_this_hfun
                 }
@@ -2389,13 +2679,18 @@ class HfunCollector(BaseHfun):
 
         # Group all applicable constant value rules by the HfunRaster they apply to.
 
-        raster_hfun_list = [
-            i for i in self._hfun_list if isinstance(i, HfunRaster)]
+        # Two counters, same reason as in _apply_flow_limiters_parallel:
+        # raster_idx matches the user's `source_index` (rasters only),
+        # hfun_idx is the real slot in _hfun_list we write the result back to.
+        raster_idx = -1
+        for hfun_idx, hfun in enumerate(self._hfun_list):
+            if not isinstance(hfun, HfunRaster):
+                continue
+            raster_idx += 1
 
-        for in_idx, hfun in enumerate(raster_hfun_list):
             rules_for_this_hfun = []
             for (src_idx, ctr0, ctr1), const_val in self._const_val_contour_coll:
-                if src_idx is None or in_idx in src_idx:
+                if src_idx is None or raster_idx in src_idx:
                     rules_for_this_hfun.append({
                         'value': const_val,
                         'lower_bound': ctr0.level if ctr0 else None,
@@ -2403,7 +2698,7 @@ class HfunCollector(BaseHfun):
                     })
 
             if rules_for_this_hfun:
-                hfuns_to_process[in_idx] = { 'hfun': hfun,
+                hfuns_to_process[hfun_idx] = { 'hfun': hfun,
                                             'rules': rules_for_this_hfun }
 
         # Now, create the simple task dictionaries for the pool.

--- a/ocsmesh/hfun/mesh.py
+++ b/ocsmesh/hfun/mesh.py
@@ -220,7 +220,7 @@ class HfunMesh(BaseHfun):
             expansion_rate: Optional[float] = None,
             target_size: Optional[float] = None,
             *, # kwarg-only comes after this
-            pool: Pool,
+            pool: Optional[Pool] = None,
             ) -> None:
         """Add refinement as a region of fixed size with an optional rate
 
@@ -321,7 +321,7 @@ class HfunMesh(BaseHfun):
             target_size: float = None,
             max_verts=200,
             *, # kwarg-only comes after this
-            pool: Pool
+            pool: Optional[Pool] = None
     ):
         """Add refinement for specified linestring `feature`
 
@@ -392,9 +392,13 @@ class HfunMesh(BaseHfun):
 
         utm_crs = utils.estimate_mesh_utm(self.mesh.meshdata)
 
+        # `pool` may be None (sequential). KDTree still needs a worker count.
+        n_workers = 1 if pool is None else pool._processes  # pylint: disable=W0212
+
         _logger.info('Repartitioning features...')
         start = time()
-        res = pool.starmap(
+        res = utils.run_starmap(
+            pool,
             utils.repartition_features,
             [(linestring, max_verts) for linestring in feature]
             )
@@ -421,7 +425,8 @@ class HfunMesh(BaseHfun):
             _logger.info(
                     f"Transform apply took {time() - start2:f}")
 
-        transformed_features = pool.starmap(
+        transformed_features = utils.run_starmap(
+            pool,
             utils.transform_linestring,
             [(linestring, target_size) for linestring in feature]
         )
@@ -452,12 +457,12 @@ class HfunMesh(BaseHfun):
         if self.hmax:
             r = (self.hmax - target_size) / (expansion_rate * target_size)
             near_dists, neighbors = tree.query(
-                xy, workers=pool._processes, distance_upper_bound=r)
+                xy, workers=n_workers, distance_upper_bound=r)
             distances = r * np.ones(len(xy))
             mask = np.logical_not(np.isinf(near_dists))
             distances[mask] = near_dists[mask]
         else:
-            distances, _ = tree.query(xy, workers=pool._processes)
+            distances, _ = tree.query(xy, workers=n_workers)
         _logger.info(f'querying kdtree took {time()-start}.')
         values = expansion_rate*target_size*distances + target_size
         # NOTE: unlike raster self.hmin is based on values of this

--- a/ocsmesh/hfun/raster.py
+++ b/ocsmesh/hfun/raster.py
@@ -890,7 +890,7 @@ class HfunRaster(BaseHfun, Raster):
             expansion_rate: Optional[float] = None,
             target_size: Optional[float] = None,
             *, # kwarg-only comes after this
-            pool: Pool,
+            pool: Optional[Pool] = None,
             ) -> None:
         """Add refinement as a region of fixed size with an optional rate
 
@@ -1102,7 +1102,7 @@ class HfunRaster(BaseHfun, Raster):
             target_size: float = 200,
             expansion_rate: Optional[float] = None,
             *,
-            pool: Pool,
+            pool: Optional[Pool] = None,
             tolerance: Optional[float] = None
             ) -> None:
         """Add refinement for auto detected channels
@@ -1172,7 +1172,7 @@ class HfunRaster(BaseHfun, Raster):
             target_size: Optional[float] = None,
             max_verts: int = 200,
             *, # kwarg-only comes after this
-            pool: Pool,
+            pool: Optional[Pool] = None,
             ) -> None:
         """Add refinement for specified linestring `feature`
 
@@ -1252,6 +1252,10 @@ class HfunRaster(BaseHfun, Raster):
                              'global hmin has been set.')
         if target_size <= 0:
             raise ValueError("Argument target_size must be greater than zero.")
+
+        # `pool` may be None (sequential). KDTree still needs a worker count.
+        n_workers = 1 if pool is None else pool._processes  # pylint: disable=W0212
+
         with self.modifying_raster(driver='GTiff') as dst:
             iter_windows = list(self.iter_windows())
             tot = len(iter_windows)
@@ -1262,7 +1266,8 @@ class HfunRaster(BaseHfun, Raster):
 
                 _logger.info('Repartitioning features...')
                 start = time()
-                res = pool.starmap(
+                res = utils.run_starmap(
+                    pool,
                     utils.repartition_features,
                     [(linestring, max_verts) for linestring in feature]
                     )
@@ -1283,7 +1288,8 @@ class HfunRaster(BaseHfun, Raster):
                     _logger.info(
                             f"Transform creation took {time() - start2:f}")
                     start2 = time()
-                    win_feature = pool.starmap(
+                    win_feature = utils.run_starmap(
+                        pool,
                         ops.transform,
                         [(transformer.transform, linestring)
                          for linestring in win_feature]
@@ -1291,7 +1297,8 @@ class HfunRaster(BaseHfun, Raster):
                     _logger.info(
                             f"Transform apply took {time() - start2:f}")
 
-                transformed_features = pool.starmap(
+                transformed_features = utils.run_starmap(
+                    pool,
                     utils.transform_linestring,
                     [(linestring, target_size) for linestring in win_feature]
                 )
@@ -1331,12 +1338,12 @@ class HfunRaster(BaseHfun, Raster):
                 if self.hmax:
                     r = (self.hmax - target_size) / (expansion_rate * target_size)
                     near_dists, neighbors = tree.query(
-                        xy, workers=pool._processes, distance_upper_bound=r)
+                        xy, workers=n_workers, distance_upper_bound=r)
                     distances = r * np.ones(len(xy))
                     mask = np.logical_not(np.isinf(near_dists))
                     distances[mask] = near_dists[mask]
                 else:
-                    distances, _ = tree.query(xy, workers=pool._processes)
+                    distances, _ = tree.query(xy, workers=n_workers)
                 _logger.info(f'Querying KDTree took {time()-start}.')
                 values = expansion_rate*target_size*distances + target_size
                 values = values.reshape(window.height, window.width).astype(

--- a/ocsmesh/utils.py
+++ b/ocsmesh/utils.py
@@ -1523,17 +1523,45 @@ def merge_meshdata(
     return composite_mesh
 
 
+def run_starmap(pool, func, iterable):
+    """Run `func(*args)` for each item, using `pool` when one exists."""
+
+    if pool is None:
+        return [func(*args) for args in iterable]
+    return pool.starmap(func, iterable)
+
+
 def add_pool_args(func):
+    """Give a function `nprocs=`/`pool=` kwargs and hand it a `pool`.
+
+    Three ways to call the wrapped function:
+
+    - `pool=<Pool>`  -> reuse that pool (no new processes are started)
+    - `nprocs=N`     -> create a pool of N processes just for this call
+    - `nprocs=1`     -> no pool at all, `pool=None` is passed instead
+
+    That last case matters: a `multiprocessing.Pool` worker is a daemon
+    process, and a daemon process is not allowed to start child processes.
+    So code running inside a worker must ask for `nprocs=1` and get `None`
+    back, otherwise Python raises
+    "daemonic processes are not allowed to have children".
+    """
+
     def wrapper(*args, nprocs=None, pool=None, **kwargs):
         if pool is not None:
-            rv = func(*args, **kwargs, pool=pool)
-        else:
-            # Check nprocs
-            nprocs = -1 if nprocs is None else nprocs
-            nprocs = cpu_count() if nprocs == -1 else nprocs
-            with Pool(processes=nprocs) as new_pool:
-                rv = func(*args, **kwargs, pool=new_pool)
-            new_pool.join()
+            return func(*args, **kwargs, pool=pool)
+
+        # Check nprocs
+        nprocs = -1 if nprocs is None else nprocs
+        nprocs = cpu_count() if nprocs == -1 else nprocs
+
+        if nprocs <= 1:
+            # Sequential: no child process, so this is safe inside a worker.
+            return func(*args, **kwargs, pool=None)
+
+        with Pool(processes=nprocs) as new_pool:
+            rv = func(*args, **kwargs, pool=new_pool)
+        new_pool.join()
         return rv
     return wrapper
 


### PR DESCRIPTION
## Summary

This PR parallelizes contour application in `HfunCollector` using the existing
file-based 3-phase worker pattern.

The old contour path is kept as `_apply_contours_serial()`. The new path is
`_apply_contours_parallel()` and is used when `execution_mode in ('parallel', 'mpi')`,
`nprocs > 1`, and `method != 'fast'`.

This PR only parallelizes contours. Channels, patches, linefeatures, MPI workers,
and bbox pre-filtering are left for follow-up PRs.

## Why

The previous implementation already used a shared `Pool`, but only inside each
`add_feature()` call. The hfuns themselves were still processed one after another
on the coordinator.

This PR changes the level of parallelism:

- shared-pool/current path: process hfuns one by one, parallelize inside `add_feature`
- per-tile/new path: process raster hfuns concurrently, one worker per tile

## Main Changes

- Added `utils.pool_starmap()` so code can use either a real process pool or
  run sequentially with `pool=None`.
- Updated `utils.add_pool_args()` so `nprocs <= 1` does not create a child
  `multiprocessing.Pool`.
- Made `pool` optional for:
  - `HfunRaster.add_feature`
  - `HfunRaster.add_patch`
  - `HfunRaster.add_channel`
  - `HfunMesh.add_feature`
  - `HfunMesh.add_patch`
- Added `_contours_task_worker()` for file-based contour processing.
- Split `_apply_contours()` into  serial path, and parallel path.